### PR TITLE
Feature: support DNS in multiaddresses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "3.2.20", features = ["derive"] }
 env_logger = "0.9.0"
 futures = "0.3.23"
 lapin = "2.1.1"
-libp2p = { version = "0.47.0", features = ["serde", "tcp-tokio"] }
+libp2p = { version = "0.47.0", features = ["serde", "tcp-tokio", "dns-tokio"] }
 libp2p-tcp = { version = "0.35.0", features = ["tokio"] }
 log = "0.4.17"
 serde = { version = "1.0.144", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use std::time::Duration;
 
 use actix_web::web::Data;
 use actix_web::{middleware, App, HttpServer};


### PR DESCRIPTION
Problem: users could not specify /dns/<hostname> multiaddresses for bootstrap peers and/or when dialing a peer dynamically.

Solution: Add the `tokio-dns` feature of libp2p and extend the TCP transport to a DNS transport. Moved the instantiation of the transport in a separate function.