### PR TITLE
Fix: Download apt dependencies early in Dockerfile

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:1.63 as builder
 WORKDIR /usr/src/p2p-service
-COPY . .
 RUN apt-get update && apt-get install -y protobuf-compiler
+COPY . .
 RUN cargo install --path .
 
 FROM debian:buster-slim


### PR DESCRIPTION
Problem: `docker build` would download dependencies on each build. Solution: Call `apt-get` as early as possible so that this layer does not change.