### PR TITLE
Feature: log HTTP listen addresses on startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -188,6 +188,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .bind(http_server_bind_address)
     .expect("bind should succeed");
 
+    info!("HTTP server listening on: {:?}", http_server.addrs());
+
     if let Err(e) = http_server.run().await {
         error!("HTTP server stopped: {:?}", e);
     }


### PR DESCRIPTION
Added an info log to check on which address(es) the HTTP server is listening.