### PR TITLE
Fix: Use "*" as routing queue for the subscribe queue

### DIFF
--- a/src/message_queue/mod.rs
+++ b/src/message_queue/mod.rs
@@ -92,7 +92,7 @@ pub async fn new(app_config: &AppConfig) -> Result<RabbitMqClient, Box<dyn std::
         .queue_bind(
             pub_queue.name().as_str(),
             pub_exchange_name,
-            "",
+            "*",
             QueueBindOptions::default(),
             FieldTable::default(),
         )


### PR DESCRIPTION
Problem: the queue receiving messages from the subscribe exchange did not receive messages from all topics, except the empty one ("").

Solution: Use "*" instead of "" as routing key.