### PR TITLE
Feature: configure number of API workers

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,8 @@ pub struct P2PConfig {
     pub peers: Vec<Multiaddr>,
     /// Topics to subscribe to.
     pub topics: Vec<String>,
+    /// Number of API workers.
+    pub nb_api_workers: usize,
 }
 
 const PEER_MULTIADDR_ERROR_MESSAGE: &str = "bootstrap peer multiaddr should be valid";
@@ -52,6 +54,7 @@ impl Default for P2PConfig {
                     .parse().expect(PEER_MULTIADDR_ERROR_MESSAGE),
             ],
             topics: vec!["ALIVE".to_owned(), "ALEPH-QUEUE".to_owned()],
+            nb_api_workers: 4,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ async fn publish_message(network_client: &mut P2PClient, delivery: &Delivery) {
 }
 
 async fn p2p_loop(
-    mut network_events: impl StreamExt<Item = p2p::network::Event> + std::marker::Unpin,
+    mut network_events: impl StreamExt<Item=p2p::network::Event> + std::marker::Unpin,
     mut network_client: P2PClient,
     mut mq_client: RabbitMqClient,
 ) {
@@ -185,8 +185,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // register HTTP requests handlers
             .configure(http::config)
     })
-    .bind(http_server_bind_address)
-    .expect("bind should succeed");
+        .workers(app_config.p2p.nb_api_workers)
+        .bind(http_server_bind_address)
+        .expect("bind should succeed");
 
     info!("HTTP server listening on: {:?}", http_server.addrs());
 


### PR DESCRIPTION
Problem: the default number of API workers in actix-web is equal to the number of logical CPUs. This service does not require 16 or more workers.

Solution: add a configuration option (`p2p.nb_api_workers`) to specify the number of workers. Set the default value to 4.