### PR TITLE
Feature: default to 127.0.0.1:5672 for RabbitMQ in Docker image

### DIFF
--- a/scripts/docker/run-p2p-service.sh
+++ b/scripts/docker/run-p2p-service.sh
@@ -35,6 +35,10 @@ function get_config() {
 RABBITMQ_HOST=$(get_config rabbitmq.host)
 RABBITMQ_PORT=$(get_config rabbitmq.port)
 
+# Set default values if connection options are not specified in the config file
+if [ -z "${RABBITMQ_HOST}" ]; then RABBITMQ_HOST="127.0.0.1"; fi
+if [ -z "${RABBITMQ_PORT}" ]; then RABBITMQ_HOST="5672"; fi
+
 wait_for_it -h "${RABBITMQ_HOST}" -p "${RABBITMQ_PORT}"
 
 exec aleph-p2p-service "${P2P_SERVICE_ARGS[@]}"


### PR DESCRIPTION
Problem: starting the Docker image may fail if the connection options are not specified in the configuration file.

Solution: use default values in the startup script if the user did not specify values for the RabbitMQ host/port.