### PR TITLE
Feature: support Sentry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ lapin = "2.1.1"
 libp2p = { version = "0.47.0", features = ["serde", "tcp-tokio", "dns-tokio"] }
 libp2p-tcp = { version = "0.35.0", features = ["tokio"] }
 log = "0.4.17"
+# Note: by default, the sentry package requires OpenSSL. We use rustls instead to avoid depending on system packages.
+sentry = { version = "0.27.0", features = ["log", "panic", "reqwest", "rustls"], default-features = false }
+sentry-actix = "0.27.0"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
 serde_yaml = "0.9.11"


### PR DESCRIPTION
Problem: developers would like to keep an eye on logs, especially errors.

Solution: add support for Sentry.

The application now logs errors to Sentry + warnings as breadcrumbs. The API server uses sentry-actix for logging of 500 errors.