### PR TITLE
Feature: list public multiaddresses in /p2p/identify

### DIFF
--- a/src/http/endpoints/error.rs
+++ b/src/http/endpoints/error.rs
@@ -1,0 +1,26 @@
+use std::fmt::{Display, Formatter};
+use actix_web::http::StatusCode;
+
+#[derive(Debug)]
+pub enum EndpointError {
+    InternalError,
+}
+
+impl Display for EndpointError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            EndpointError::InternalError => "internal error",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+impl std::error::Error for EndpointError {}
+
+impl actix_web::ResponseError for EndpointError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Self::InternalError => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}

--- a/src/http/endpoints/mod.rs
+++ b/src/http/endpoints/mod.rs
@@ -1,2 +1,3 @@
 pub mod dial;
+mod error;
 pub mod identity;


### PR DESCRIPTION
Problem: users of the service would like to know through which address the node is accessible.
Solution: expose the external addresses of the P2P swarm in the /p2p/identify endpoint.

Added a new command, `Identify`, that returns the local peer ID and the list of external addresses of the swarm.