### PR TITLE
Fix: avoid reading RabbitMQ messages without ack-ing them

### DIFF
--- a/src/message_queue/mod.rs
+++ b/src/message_queue/mod.rs
@@ -16,6 +16,7 @@ use crate::config::AppConfig;
 ///    (= the "pub" exchange/queue).
 /// 2. An exchange where the P2P service will publish pubsub messages received over the P2P
 ///    network for the other processes on the node to consume (= the "sub" exchange).
+#[derive(Clone)]
 pub struct RabbitMqClient {
     channel: Channel,
     pub_consumer: Consumer,


### PR DESCRIPTION
Problem: the P2P service hangs randomly because a message was not acknowledged within 30 minutes of being fetched for the pub queue.

Solution: run the P2P <-> MQ tasks in two separate tasks instead of using `tokio::select!`.

`tokio::select!` cancels the future(s) that did not complete. This is the probable cause of the issue. Introduced two new tasks to replace the `p2p_loop` task so that they run uninterrupted.