### PR TITLE
Internal: rewrite the dial endpoint

### DIFF
--- a/src/http/endpoints/error.rs
+++ b/src/http/endpoints/error.rs
@@ -3,13 +3,18 @@ use actix_web::http::StatusCode;
 
 #[derive(Debug)]
 pub enum EndpointError {
+    Forbidden,
+    NotFound,
     InternalError,
 }
+
 
 impl Display for EndpointError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let s = match self {
-            EndpointError::InternalError => "internal error",
+            Self::Forbidden => "forbidden",
+            Self::NotFound => "not found",
+            Self::InternalError => "internal error",
         };
         write!(f, "{}", s)
     }
@@ -20,6 +25,8 @@ impl std::error::Error for EndpointError {}
 impl actix_web::ResponseError for EndpointError {
     fn status_code(&self) -> StatusCode {
         match self {
+            Self::Forbidden => StatusCode::FORBIDDEN,
+            Self::NotFound => StatusCode::NOT_FOUND,
             Self::InternalError => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }


### PR DESCRIPTION
Problem: the dial endpoint implementation was "not great". 
Solution: rewrite it using the new `EndpointError` enum.

The new implementation is more concise and clearer in intent. Split the logic and the error conversion.