### PR TITLE
Fix: Failed to join network using configured peers

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -46,11 +46,9 @@ impl Default for P2PConfig {
             alive_topic: "ALIVE".to_owned(),
             clients: vec!["http".to_owned()],
             peers: vec![
-                "/ip4/51.159.57.71/tcp/4025/p2p/QmZkurbY2G2hWay59yiTgQNaQxHSNzKZFt2jbnwJhQcKgV"
+                "/dns/api1.aleph.im/tcp/4025/p2p/Qmaxufiqdyt5uVWcy1Xh2nh3Rs3382ArnSP2umjCiNG2Vs"
                     .parse().expect(PEER_MULTIADDR_ERROR_MESSAGE),
-                "/ip4/95.216.100.234/tcp/4025/p2p/Qmaxufiqdyt5uVWcy1Xh2nh3Rs3382ArnSP2umjCiNG2Vs"
-                    .parse().expect(PEER_MULTIADDR_ERROR_MESSAGE),
-                "/ip4/62.210.93.220/tcp/4025/p2p/QmXdci5feFmA2pxTg8p3FCyWmSKnWYAAmr7Uys1YCTFD8U"
+                "/dns/api2.aleph.im/tcp/4025/p2p/QmZkurbY2G2hWay59yiTgQNaQxHSNzKZFt2jbnwJhQcKgV"
                     .parse().expect(PEER_MULTIADDR_ERROR_MESSAGE),
             ],
             topics: vec!["ALIVE".to_owned(), "ALEPH-QUEUE".to_owned()],


### PR DESCRIPTION
The p2p service failed to connect to the rest of the network using the configured peers. The default configuration of `pyaleph` is in Python code and cannot be read from this service.

Solution: Copy the default peers from `pyaleph` into the configuration of p2p-service.