### PR TITLE
Fix: no error log on event loop stopping

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,7 @@ async fn p2p_to_mq_loop(mut mq_client: RabbitMqClient, mut network_events: impl 
             }
         }
     }
-    error!("Event loop stopped");
+    info!("Event loop stopped");
 }
 
 fn configure_logging() {


### PR DESCRIPTION
The event loop stopping occurs normally when the service is stopped and is not an error.