### PR TITLE
Fix: support concurrent P2P API calls

### DIFF
--- a/src/http/endpoints/error.rs
+++ b/src/http/endpoints/error.rs
@@ -6,6 +6,7 @@ pub enum EndpointError {
     Forbidden,
     NotFound,
     InternalError,
+    ServiceUnavailable,
 }
 
 impl Display for EndpointError {
@@ -14,6 +15,7 @@ impl Display for EndpointError {
             Self::Forbidden => "forbidden",
             Self::NotFound => "not found",
             Self::InternalError => "internal error",
+            Self::ServiceUnavailable => "service unavailable",
         };
         write!(f, "{s}")
     }
@@ -27,6 +29,7 @@ impl actix_web::ResponseError for EndpointError {
             Self::Forbidden => StatusCode::FORBIDDEN,
             Self::NotFound => StatusCode::NOT_FOUND,
             Self::InternalError => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::ServiceUnavailable => StatusCode::SERVICE_UNAVAILABLE,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ async fn dial_bootstrap_peers(network_client: &mut P2PClient, peers: &[Multiaddr
                 continue;
             }
         };
-        match network_client.dial(peer_id, addr).await {
+        match network_client.dial_and_wait(peer_id, addr).await {
             Ok(_) => info!("Successfully dialed bootstrap peer: {}", &peer_addr),
             Err(e) => error!("Failed to dial bootstrap peer {}: {}", peer_addr, e),
         }


### PR DESCRIPTION
Problem: API calls are serialized because we use the mutex around the P2P client object a bit too generously in the API.

Solution: lock the mutex for a shorter amount of time. We now lock the mutex for the time needed to send the command to the P2P background task and then wait for the result after unlocking the mutex.