### PR TITLE
Fix: Remove references to slow server api1.aleph.im

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -46,10 +46,10 @@ impl Default for P2PConfig {
             alive_topic: "ALIVE".to_owned(),
             clients: vec!["http".to_owned()],
             peers: vec![
-                "/dns/api1.aleph.im/tcp/4025/p2p/Qmaxufiqdyt5uVWcy1Xh2nh3Rs3382ArnSP2umjCiNG2Vs"
+                "/dns/api2.aleph.im/tcp/4025/p2p/QmZkurbY2G2hWay59yiTgQNaQxHSNzKZFt2jbnwJhQcKgV"
                     .parse()
                     .expect(PEER_MULTIADDR_ERROR_MESSAGE),
-                "/dns/api2.aleph.im/tcp/4025/p2p/QmZkurbY2G2hWay59yiTgQNaQxHSNzKZFt2jbnwJhQcKgV"
+                "/dns/api3.aleph.im/tcp/4025/p2p/Qmb5b2ZwJm9pVWrppf3D3iMF1bXbjZhbJTwGvKEBMZNxa2",
                     .parse()
                     .expect(PEER_MULTIADDR_ERROR_MESSAGE),
             ],


### PR DESCRIPTION
Server api1.aleph.im is very slow and outdated
(Core i7 from 2018, up to 40 seconds to respond
to `/metrics` in the monitoring).

We suspect that this causes issues in the
monitoring and performance of the network.

This branch removes all references to api1 and
replaces them with api3 where relevant.
