### PR TITLE
v2.0: /aleph/fetch/1.0.0 content fetch protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,7 @@ version = "2.0.0"
 dependencies = [
  "actix-web",
  "async-stream",
+ "cbor4ii",
  "chrono",
  "clap",
  "env_logger",
@@ -258,10 +259,12 @@ dependencies = [
  "libp2p 0.51.4",
  "libp2p 0.56.0",
  "libp2p-mplex",
+ "libp2p-stream",
  "log",
  "prometheus-client 0.23.1",
  "prost 0.13.5",
  "rand 0.8.6",
+ "reqwest 0.12.28",
  "sentry",
  "sentry-actix",
  "serde",
@@ -271,6 +274,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tonic",
  "tonic-build",
 ]
@@ -718,6 +722,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
 dependencies = [
  "bytes",
+]
+
+[[package]]
+name = "cbor4ii"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faed1a83001dc2c9201451030cc317e35bef36c84d3781d7c5bb9f343c397da8"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1847,13 +1860,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.4.2",
  "http-body 1.0.1",
  "hyper 1.10.1",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.4",
  "tokio",
@@ -2720,6 +2736,20 @@ dependencies = [
  "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-stream"
+version = "0.4.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6bd8025c80205ec2810cfb28b02f362ab48a01bee32c50ab5f12761e033464"
+dependencies = [
+ "futures",
+ "libp2p-core 0.43.2",
+ "libp2p-identity 0.2.14",
+ "libp2p-swarm 0.47.1",
+ "rand 0.8.6",
  "tracing",
 ]
 
@@ -4006,6 +4036,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-util",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4249,7 +4314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce4b57f1b521f674df7a1d200be8ff5d74e3712020ee25b553146657b5377d5"
 dependencies = [
  "httpdate",
- "reqwest",
+ "reqwest 0.11.27",
  "rustls 0.21.12",
  "sentry-core 0.31.8",
  "sentry-log",
@@ -4598,6 +4663,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -4837,6 +4905,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -4925,8 +4994,27 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper 1.0.2",
+ "tokio",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytes",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "pin-project-lite",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -5302,6 +5390,19 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,8 +251,10 @@ version = "2.0.0"
 dependencies = [
  "actix-web",
  "async-stream",
+ "bytes",
  "cbor4ii",
  "chrono",
+ "cid",
  "clap",
  "env_logger",
  "futures",
@@ -791,6 +793,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cid"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a304f95f84d169a6f31c4d0a30d784643aaa0bbc9c1e449a2c23e963ec4971"
+dependencies = [
+ "multibase",
+ "multihash 0.19.5",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,12 @@ tonic = "0.12"
 prost = "0.13"
 async-stream = "0.3"
 libp2p-stream = "0.4.0-alpha"
-tokio-util = { version = "0.7.18", features = ["compat"] }
+tokio-util = { version = "0.7.18", features = ["compat", "io"] }
+cid = "0.11"
+bytes = "1"
 # Pinned to 0.12: reqwest 0.13 requires time 0.3.48, which the workspace
 # caps below (see the time entry). Bump the two together.
-reqwest = { version = "0.12", default-features = false, features = ["stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["stream", "json"] }
 cbor4ii = { version = "1.2.2", features = ["serde1", "use_std"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ prost = "0.13"
 async-stream = "0.3"
 libp2p-stream = "0.4.0-alpha"
 tokio-util = { version = "0.7.18", features = ["compat"] }
+# Pinned to 0.12: reqwest 0.13 pulls time 0.3.48, which conflicts with the
+# cookie 0.16 dependency of actix-web. Revisit after an actix-web upgrade.
 reqwest = { version = "0.12", default-features = false, features = ["stream"] }
 cbor4ii = { version = "1.2.2", features = ["serde1", "use_std"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ cbor4ii = { version = "1.2.2", features = ["serde1", "use_std"] }
 # gossipsub wire compatibility in tests/interop_old_libp2p.rs.
 libp2p-old = { package = "libp2p", version = "0.51.3", features = ["dns", "gossipsub", "macros", "noise", "tcp", "tokio", "yamux"] }
 tempfile = "3"
+# test-util enables the paused clock used by the fetch cooldown tests.
+tokio = { version = "1.43.0", features = ["full", "test-util"] }
 
 [build-dependencies]
 tonic-build = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ rand = "0.8"
 tonic = "0.12"
 prost = "0.13"
 async-stream = "0.3"
+libp2p-stream = "0.4.0-alpha"
+tokio-util = { version = "0.7.18", features = ["compat"] }
+reqwest = { version = "0.12", default-features = false, features = ["stream"] }
+cbor4ii = { version = "1.2.2", features = ["serde1", "use_std"] }
 
 [dev-dependencies]
 # Old libp2p stack used by deployed nodes; kept as a dev-dependency to prove

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ prost = "0.13"
 async-stream = "0.3"
 libp2p-stream = "0.4.0-alpha"
 tokio-util = { version = "0.7.18", features = ["compat"] }
-# Pinned to 0.12: reqwest 0.13 pulls time 0.3.48, which conflicts with the
-# cookie 0.16 dependency of actix-web. Revisit after an actix-web upgrade.
+# Pinned to 0.12: reqwest 0.13 requires time 0.3.48, which the workspace
+# caps below (see the time entry). Bump the two together.
 reqwest = { version = "0.12", default-features = false, features = ["stream"] }
 cbor4ii = { version = "1.2.2", features = ["serde1", "use_std"] }
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,26 @@ with pyaleph (the Core Channel Node software). The `AlephP2P` service provides:
   reported as truncated.
 * `GetPeers`: lists currently connected peers with their multiaddrs, preferred flag
   and gossipsub score.
+* `Fetch`: server-streaming RPC retrieving hash-addressed content from peers
+  over the `/aleph/fetch/1.0.0` libp2p protocol. The service tries caller
+  hints first, then connected peers (preferred first), with per-peer timeouts
+  and a total deadline. The caller (pyaleph) verifies the content hash; the
+  service only enforces size and rate limits.
 
 The node also subscribes at startup to every topic listed in the `p2p.topics`
 configuration variable.
 
-**Security note:** The gRPC API is unauthenticated and intended for deployment-internal use only. Bind it to localhost or an internal container network and firewall the port (the demo compose binds `127.0.0.1`). Anyone with network access to the port can publish messages, change the preferred peer set, or trigger dials.
+**Security note:** The gRPC API is unauthenticated and intended for deployment-internal use only. Bind it to localhost or an internal container network and firewall the port (the demo compose binds `127.0.0.1`). Anyone with network access to the port can publish messages, change the preferred peer set, or trigger dials. The `/aleph/fetch/1.0.0` libp2p protocol adds a remote surface, but serving inbound fetch requests is disabled unless `p2p.content_provider_url` is set.
+
+### Content fetch protocol
+
+Nodes exchange hash-addressed content over the `/aleph/fetch/1.0.0` libp2p
+protocol. On the provider side, an inbound fetch request for a hash is served
+by an HTTP GET to `p2p.content_provider_url` at `/api/v0/storage/raw/{hash}`
+(the local pyaleph API), streaming the response body back to the requesting
+peer. While `p2p.content_provider_url` is empty (the default), serving is
+disabled and the node answers every request with "not found"; existing
+deployments keep working without configuration changes.
 
 ### Metrics and health
 
@@ -82,6 +97,14 @@ All fields have defaults; an empty `p2p: {}` section is valid.
 | `p2p.max_protected_share` | `0.5` | Maximum share of `high_water` that preferred peers may occupy. |
 | `p2p.peerstore_path` | `peerstore.json` | Path of the persisted peerstore file. |
 | `p2p.maintenance_interval_secs` | `30` | Seconds between mesh maintenance passes. |
+| `p2p.content_provider_url` | empty (disabled) | Base URL of the local pyaleph API used to serve fetch requests, e.g. `http://pyaleph-api:4024`. |
+| `p2p.fetch_max_size_bytes` | `268435456` | Maximum content size served or accepted (256 MiB). |
+| `p2p.fetch_max_inbound_streams` | `32` | Global cap on concurrent inbound fetch streams. |
+| `p2p.fetch_max_inbound_streams_per_peer` | `4` | Per-peer cap on concurrent inbound fetch streams. |
+| `p2p.fetch_serve_bytes_per_sec` | `67108864` | Token-bucket limit on served bytes per second (0 = unlimited). |
+| `p2p.fetch_peer_timeout_secs` | `10` | Per-peer timeout for each fetch step. |
+| `p2p.fetch_total_deadline_secs` | `60` | Total deadline of one Fetch RPC. |
+| `p2p.fetch_max_peer_attempts` | `5` | Maximum peers tried per Fetch RPC. |
 | `sentry.dsn` | unset | Sentry DSN; error reporting is disabled when unset. |
 | `sentry.traces_sample_rate` | unset | Sentry traces sample rate. |
 

--- a/README.md
+++ b/README.md
@@ -68,14 +68,20 @@ local sources in order:
 1. **Filesystem** (`p2p.content_dir`): pyaleph stores content as flat files
    named by their item hash in a content-addressed folder. If the file is
    present and within the size limit it is streamed to the requester.
-2. **Local Kubo** (`p2p.ipfs_api_url`): if the item hash parses as a CID,
-   the local IPFS daemon (Kubo) is queried with `offline=true`. This flag
-   instructs Kubo to return an error instead of fetching the block from the
-   public IPFS network; only locally resident blocks are served.
+2. **Kubo** (`p2p.ipfs_api_url`): if the item hash parses as a CID, the IPFS
+   daemon (Kubo) is queried with `offline=true`. This flag instructs Kubo to
+   return an error instead of fetching the block from the public IPFS network;
+   only locally resident blocks are served. Point `ipfs_api_url` at the node
+   that actually holds the pinned content: the local daemon in a single-node
+   setup, or the pinning node if pyaleph offloads IPFS storage (it must match
+   pyaleph's `ipfs.pinning` endpoint). The node is queried read-only (`cat`,
+   `files/stat`); the provider never pins or writes.
 3. **Not found**: the requester falls through to its own IPFS resolution path.
 
 Serving is disabled when both `content_dir` and `ipfs_api_url` are empty
 (the default); existing deployments keep working without configuration changes.
+Filesystem serving is independent of IPFS pinning, so a node that offloads
+pinning still serves its locally stored (e.g. STORE) content from `content_dir`.
 
 ### Metrics and health
 
@@ -106,7 +112,7 @@ All fields have defaults; an empty `p2p: {}` section is valid.
 | `p2p.peerstore_path` | `peerstore.json` | Path of the persisted peerstore file. |
 | `p2p.maintenance_interval_secs` | `30` | Seconds between mesh maintenance passes. |
 | `p2p.content_dir` | empty (disabled) | Path of pyaleph's content-addressed storage folder (flat files named by item hash). Empty disables filesystem serving. |
-| `p2p.ipfs_api_url` | empty (disabled) | Base URL of the local Kubo (IPFS daemon) RPC API, e.g. `http://ipfs:5001`. Empty disables IPFS serving. Kubo is always queried with `offline=true`; it will never fetch blocks from the public network on behalf of an inbound request. |
+| `p2p.ipfs_api_url` | empty (disabled) | Base URL of the Kubo (IPFS daemon) RPC API that holds the node's pinned content, e.g. `http://ipfs:5001`. Use the pinning node here if pyaleph offloads IPFS storage (match `ipfs.pinning`). Empty disables IPFS serving. Kubo is always queried with `offline=true`; it will never fetch blocks from the public network on behalf of an inbound request. |
 | `p2p.fetch_max_size_bytes` | `268435456` | Maximum content size served or accepted (256 MiB). |
 | `p2p.fetch_max_inbound_streams` | `32` | Global cap on concurrent inbound fetch streams. |
 | `p2p.fetch_max_inbound_streams_per_peer` | `4` | Per-peer cap on concurrent inbound fetch streams. |

--- a/README.md
+++ b/README.md
@@ -57,17 +57,25 @@ with pyaleph (the Core Channel Node software). The `AlephP2P` service provides:
 The node also subscribes at startup to every topic listed in the `p2p.topics`
 configuration variable.
 
-**Security note:** The gRPC API is unauthenticated and intended for deployment-internal use only. Bind it to localhost or an internal container network and firewall the port (the demo compose binds `127.0.0.1`). Anyone with network access to the port can publish messages, change the preferred peer set, or trigger dials. The `/aleph/fetch/1.0.0` libp2p protocol adds a remote surface, but serving inbound fetch requests is disabled unless `p2p.content_provider_url` is set.
+**Security note:** The gRPC API is unauthenticated and intended for deployment-internal use only. Bind it to localhost or an internal container network and firewall the port (the demo compose binds `127.0.0.1`). Anyone with network access to the port can publish messages, change the preferred peer set, or trigger dials. The `/aleph/fetch/1.0.0` libp2p protocol adds a remote surface, but serving inbound fetch requests is disabled unless at least one of `p2p.content_dir` or `p2p.ipfs_api_url` is set.
 
 ### Content fetch protocol
 
 Nodes exchange hash-addressed content over the `/aleph/fetch/1.0.0` libp2p
-protocol. On the provider side, an inbound fetch request for a hash is served
-by an HTTP GET to `p2p.content_provider_url` at `/api/v0/storage/raw/{hash}`
-(the local pyaleph API), streaming the response body back to the requesting
-peer. While `p2p.content_provider_url` is empty (the default), serving is
-disabled and the node answers every request with "not found"; existing
-deployments keep working without configuration changes.
+protocol. On the provider side, an inbound fetch request is resolved from
+local sources in order:
+
+1. **Filesystem** (`p2p.content_dir`): pyaleph stores content as flat files
+   named by their item hash in a content-addressed folder. If the file is
+   present and within the size limit it is streamed to the requester.
+2. **Local Kubo** (`p2p.ipfs_api_url`): if the item hash parses as a CID,
+   the local IPFS daemon (Kubo) is queried with `offline=true`. This flag
+   instructs Kubo to return an error instead of fetching the block from the
+   public IPFS network; only locally resident blocks are served.
+3. **Not found**: the requester falls through to its own IPFS resolution path.
+
+Serving is disabled when both `content_dir` and `ipfs_api_url` are empty
+(the default); existing deployments keep working without configuration changes.
 
 ### Metrics and health
 
@@ -97,7 +105,8 @@ All fields have defaults; an empty `p2p: {}` section is valid.
 | `p2p.max_protected_share` | `0.5` | Maximum share of `high_water` that preferred peers may occupy. |
 | `p2p.peerstore_path` | `peerstore.json` | Path of the persisted peerstore file. |
 | `p2p.maintenance_interval_secs` | `30` | Seconds between mesh maintenance passes. |
-| `p2p.content_provider_url` | empty (disabled) | Base URL of the local pyaleph API used to serve fetch requests, e.g. `http://pyaleph-api:4024`. |
+| `p2p.content_dir` | empty (disabled) | Path of pyaleph's content-addressed storage folder (flat files named by item hash). Empty disables filesystem serving. |
+| `p2p.ipfs_api_url` | empty (disabled) | Base URL of the local Kubo (IPFS daemon) RPC API, e.g. `http://ipfs:5001`. Empty disables IPFS serving. Kubo is always queried with `offline=true`; it will never fetch blocks from the public network on behalf of an inbound request. |
 | `p2p.fetch_max_size_bytes` | `268435456` | Maximum content size served or accepted (256 MiB). |
 | `p2p.fetch_max_inbound_streams` | `32` | Global cap on concurrent inbound fetch streams. |
 | `p2p.fetch_max_inbound_streams_per_peer` | `4` | Per-peer cap on concurrent inbound fetch streams. |

--- a/proto/aleph_p2p.proto
+++ b/proto/aleph_p2p.proto
@@ -25,6 +25,9 @@ service AlephP2P {
   rpc SetPreferredPeers(SetPreferredPeersRequest) returns (SetPreferredPeersResponse);
   // List currently connected peers.
   rpc GetPeers(GetPeersRequest) returns (GetPeersResponse);
+  // Retrieve hash-addressed content from peers over the /aleph/fetch/1.0.0
+  // libp2p protocol. Server-streaming: chunks arrive as the content is fetched.
+  rpc Fetch(FetchRequest) returns (stream FetchChunk);
 }
 
 message IdentifyRequest {}
@@ -91,4 +94,16 @@ message PeerInfo {
   repeated string multiaddrs = 2;
   bool preferred = 3;
   double score = 4;
+}
+
+message FetchRequest {
+  string item_hash = 1;
+  // Optional dial/order hints; tried first. Invalid entries are skipped.
+  repeated string preferred_peer_ids = 2;
+}
+
+message FetchChunk {
+  bytes data = 1;
+  // Total content size in bytes; set on every chunk.
+  uint64 total_size = 2;
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,56 @@ pub struct P2PConfig {
     /// Seconds between mesh maintenance passes (bootstrap anchoring,
     /// preferred-peer dialing, low-water refill from the peerstore).
     pub maintenance_interval_secs: u64,
+    /// Base URL of the local pyaleph API used to serve inbound fetch
+    /// requests. Empty string disables the provider side.
+    #[serde(default = "default_content_provider_url")]
+    pub content_provider_url: String,
+    /// Maximum content size served or accepted by the fetch protocol.
+    #[serde(default = "default_fetch_max_size_bytes")]
+    pub fetch_max_size_bytes: u64,
+    /// Maximum concurrent inbound fetch streams (global).
+    #[serde(default = "default_fetch_max_inbound_streams")]
+    pub fetch_max_inbound_streams: usize,
+    /// Maximum concurrent inbound fetch streams per remote peer.
+    #[serde(default = "default_fetch_max_inbound_streams_per_peer")]
+    pub fetch_max_inbound_streams_per_peer: usize,
+    /// Token-bucket rate limit on bytes served, per second. 0 disables it.
+    #[serde(default = "default_fetch_serve_bytes_per_sec")]
+    pub fetch_serve_bytes_per_sec: u64,
+    /// Per-peer timeout for one fetch attempt step (open/header/chunk read).
+    #[serde(default = "default_fetch_peer_timeout_secs")]
+    pub fetch_peer_timeout_secs: u64,
+    /// Total wall-clock deadline for a Fetch RPC.
+    #[serde(default = "default_fetch_total_deadline_secs")]
+    pub fetch_total_deadline_secs: u64,
+    /// Maximum number of peers tried per Fetch RPC.
+    #[serde(default = "default_fetch_max_peer_attempts")]
+    pub fetch_max_peer_attempts: usize,
+}
+
+fn default_content_provider_url() -> String {
+    String::new()
+}
+fn default_fetch_max_size_bytes() -> u64 {
+    256 * 1024 * 1024
+}
+fn default_fetch_max_inbound_streams() -> usize {
+    32
+}
+fn default_fetch_max_inbound_streams_per_peer() -> usize {
+    4
+}
+fn default_fetch_serve_bytes_per_sec() -> u64 {
+    64 * 1024 * 1024
+}
+fn default_fetch_peer_timeout_secs() -> u64 {
+    10
+}
+fn default_fetch_total_deadline_secs() -> u64 {
+    60
+}
+fn default_fetch_max_peer_attempts() -> usize {
+    5
 }
 
 const PEER_MULTIADDR_ERROR_MESSAGE: &str = "bootstrap peer multiaddr should be valid";
@@ -68,6 +118,14 @@ impl Default for P2PConfig {
             per_subnet_cap: 4,
             max_protected_share: 0.5,
             maintenance_interval_secs: 30,
+            content_provider_url: default_content_provider_url(),
+            fetch_max_size_bytes: default_fetch_max_size_bytes(),
+            fetch_max_inbound_streams: default_fetch_max_inbound_streams(),
+            fetch_max_inbound_streams_per_peer: default_fetch_max_inbound_streams_per_peer(),
+            fetch_serve_bytes_per_sec: default_fetch_serve_bytes_per_sec(),
+            fetch_peer_timeout_secs: default_fetch_peer_timeout_secs(),
+            fetch_total_deadline_secs: default_fetch_total_deadline_secs(),
+            fetch_max_peer_attempts: default_fetch_max_peer_attempts(),
         }
     }
 }
@@ -125,5 +183,18 @@ rabbitmq:
             config.p2p.topics,
             vec!["ALIVE".to_string(), "ALEPH-TEST".to_string()]
         );
+    }
+
+    #[test]
+    fn fetch_defaults_are_sane() {
+        let config = P2PConfig::default();
+        assert!(config.content_provider_url.is_empty());
+        assert_eq!(config.fetch_max_size_bytes, 256 * 1024 * 1024);
+        assert_eq!(config.fetch_max_inbound_streams, 32);
+        assert_eq!(config.fetch_max_inbound_streams_per_peer, 4);
+        assert_eq!(config.fetch_serve_bytes_per_sec, 64 * 1024 * 1024);
+        assert_eq!(config.fetch_peer_timeout_secs, 10);
+        assert_eq!(config.fetch_total_deadline_secs, 60);
+        assert_eq!(config.fetch_max_peer_attempts, 5);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,10 +41,14 @@ pub struct P2PConfig {
     /// Seconds between mesh maintenance passes (bootstrap anchoring,
     /// preferred-peer dialing, low-water refill from the peerstore).
     pub maintenance_interval_secs: u64,
-    /// Base URL of the local pyaleph API used to serve inbound fetch
-    /// requests. Empty string disables the provider side.
-    #[serde(default = "default_content_provider_url")]
-    pub content_provider_url: String,
+    /// Path of pyaleph's content-addressed storage folder (flat files named by
+    /// item hash). Empty string disables filesystem serving.
+    #[serde(default)]
+    pub content_dir: String,
+    /// Base URL of the local Kubo (IPFS daemon) RPC API, e.g.
+    /// `http://ipfs:5001`. Empty string disables IPFS serving.
+    #[serde(default)]
+    pub ipfs_api_url: String,
     /// Maximum content size served or accepted by the fetch protocol.
     #[serde(default = "default_fetch_max_size_bytes")]
     pub fetch_max_size_bytes: u64,
@@ -68,9 +72,6 @@ pub struct P2PConfig {
     pub fetch_max_peer_attempts: usize,
 }
 
-fn default_content_provider_url() -> String {
-    String::new()
-}
 fn default_fetch_max_size_bytes() -> u64 {
     256 * 1024 * 1024
 }
@@ -118,7 +119,8 @@ impl Default for P2PConfig {
             per_subnet_cap: 4,
             max_protected_share: 0.5,
             maintenance_interval_secs: 30,
-            content_provider_url: default_content_provider_url(),
+            content_dir: String::new(),
+            ipfs_api_url: String::new(),
             fetch_max_size_bytes: default_fetch_max_size_bytes(),
             fetch_max_inbound_streams: default_fetch_max_inbound_streams(),
             fetch_max_inbound_streams_per_peer: default_fetch_max_inbound_streams_per_peer(),
@@ -188,7 +190,8 @@ rabbitmq:
     #[test]
     fn fetch_defaults_are_sane() {
         let config = P2PConfig::default();
-        assert!(config.content_provider_url.is_empty());
+        assert!(config.content_dir.is_empty());
+        assert!(config.ipfs_api_url.is_empty());
         assert_eq!(config.fetch_max_size_bytes, 256 * 1024 * 1024);
         assert_eq!(config.fetch_max_inbound_streams, 32);
         assert_eq!(config.fetch_max_inbound_streams_per_peer, 4);

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -1,0 +1,15 @@
+// NOTE: provider and requester land in later tasks; the declarations are
+// commented out so the crate compiles at every step.
+// pub mod provider;
+// pub mod requester;
+pub mod wire;
+
+use libp2p::StreamProtocol;
+
+pub const FETCH_PROTOCOL: StreamProtocol = StreamProtocol::new("/aleph/fetch/1.0.0");
+
+/// Hashes are sha256 hex digests or base58/base32 CIDs; this guard also
+/// prevents path traversal when the hash is interpolated into the provider URL.
+pub fn is_valid_item_hash(hash: &str) -> bool {
+    !hash.is_empty() && hash.len() <= 128 && hash.bytes().all(|b| b.is_ascii_alphanumeric())
+}

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -1,7 +1,5 @@
-// NOTE: requester lands in a later task; the declaration is commented out
-// so the crate compiles at every step.
 pub mod provider;
-// pub mod requester;
+pub mod requester;
 pub mod wire;
 
 use libp2p::StreamProtocol;

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -1,6 +1,6 @@
-// NOTE: provider and requester land in later tasks; the declarations are
-// commented out so the crate compiles at every step.
-// pub mod provider;
+// NOTE: requester lands in a later task; the declaration is commented out
+// so the crate compiles at every step.
+pub mod provider;
 // pub mod requester;
 pub mod wire;
 

--- a/src/fetch/provider.rs
+++ b/src/fetch/provider.rs
@@ -57,6 +57,9 @@ impl ByteRateLimiter {
         if self.bytes_per_sec == 0 {
             return;
         }
+        // The bucket capacity is one second of budget; clamp the cost so a
+        // chunk larger than the capacity throttles instead of spinning forever.
+        let n = n.min(self.bytes_per_sec as usize);
         loop {
             let elapsed = self.last_refill.elapsed().as_secs_f64();
             self.available = (self.available + elapsed * self.bytes_per_sec as f64)
@@ -225,6 +228,13 @@ where
 mod tests {
     use super::*;
     use tokio::io::AsyncReadExt;
+
+    #[tokio::test(start_paused = true)]
+    async fn rate_limiter_clamps_costs_larger_than_capacity() {
+        // A cost above one second of budget must throttle, not spin forever.
+        let mut limiter = ByteRateLimiter::new(1024);
+        limiter.acquire(64 * 1024).await;
+    }
 
     /// Serves HTTP requests: 200 with `content` for /api/v0/storage/raw/<known_hash>,
     /// 404 otherwise. Closes the connection after responding.

--- a/src/fetch/provider.rs
+++ b/src/fetch/provider.rs
@@ -1,0 +1,387 @@
+//! Provider side of the `/aleph/fetch/1.0.0` protocol.
+//!
+//! The provider holds no storage: every inbound request is proxied to the
+//! local pyaleph API (`GET {content_provider_url}/api/v0/storage/raw/{hash}`)
+//! and the response body is relayed to the remote peer. Serving is disabled
+//! while `provider_url` is `None`; every request is then answered with
+//! `found: false` so old deployments keep working without config changes.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+use libp2p::PeerId;
+use log::{debug, warn};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use tokio::sync::{Mutex, Semaphore};
+use tokio::time::{timeout, Instant};
+use tokio_util::compat::FuturesAsyncReadCompatExt;
+
+use crate::fetch::is_valid_item_hash;
+use crate::fetch::wire::{read_frame, write_frame, FetchRequest, FetchResponseHeader};
+use crate::metrics::Metrics;
+
+const REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(10);
+const BACKEND_TIMEOUT: Duration = Duration::from_secs(60);
+
+#[derive(Clone)]
+pub struct ProviderSettings {
+    /// None disables serving (every request answered found=false).
+    pub provider_url: Option<String>,
+    pub max_size_bytes: u64,
+    pub max_inbound_streams: usize,
+    pub max_inbound_streams_per_peer: usize,
+    /// 0 disables rate limiting.
+    pub serve_bytes_per_sec: u64,
+}
+
+/// Minimal token bucket over served bytes. Capacity is one second of budget.
+pub struct ByteRateLimiter {
+    bytes_per_sec: u64,
+    available: f64,
+    last_refill: Instant,
+}
+
+impl ByteRateLimiter {
+    pub fn new(bytes_per_sec: u64) -> Self {
+        Self {
+            bytes_per_sec,
+            available: bytes_per_sec as f64,
+            last_refill: Instant::now(),
+        }
+    }
+
+    /// Waits until `n` bytes of budget are available, then consumes them.
+    pub async fn acquire(&mut self, n: usize) {
+        if self.bytes_per_sec == 0 {
+            return;
+        }
+        loop {
+            let elapsed = self.last_refill.elapsed().as_secs_f64();
+            self.available = (self.available + elapsed * self.bytes_per_sec as f64)
+                .min(self.bytes_per_sec as f64);
+            self.last_refill = Instant::now();
+            if self.available >= n as f64 {
+                self.available -= n as f64;
+                return;
+            }
+            let deficit = n as f64 - self.available;
+            tokio::time::sleep(Duration::from_secs_f64(deficit / self.bytes_per_sec as f64)).await;
+        }
+    }
+}
+
+pub async fn run(
+    mut incoming: libp2p_stream::IncomingStreams,
+    settings: ProviderSettings,
+    metrics: Metrics,
+) {
+    let http = reqwest::Client::builder()
+        .timeout(BACKEND_TIMEOUT)
+        .build()
+        .expect("reqwest client construction cannot fail with static settings");
+    let global_slots = Arc::new(Semaphore::new(settings.max_inbound_streams));
+    let per_peer: Arc<Mutex<HashMap<PeerId, usize>>> = Arc::new(Mutex::new(HashMap::new()));
+    let limiter = Arc::new(Mutex::new(ByteRateLimiter::new(
+        settings.serve_bytes_per_sec,
+    )));
+
+    while let Some((peer, stream)) = incoming.next().await {
+        let Ok(permit) = global_slots.clone().try_acquire_owned() else {
+            metrics.increment_event("fetch_serve_rejected_busy");
+            drop(stream);
+            continue;
+        };
+        {
+            let mut counts = per_peer.lock().await;
+            let count = counts.entry(peer).or_insert(0);
+            if *count >= settings.max_inbound_streams_per_peer {
+                metrics.increment_event("fetch_serve_rejected_busy");
+                drop(stream);
+                continue;
+            }
+            *count += 1;
+        }
+        let settings = settings.clone();
+        let http = http.clone();
+        let metrics = metrics.clone();
+        let per_peer = per_peer.clone();
+        let limiter = limiter.clone();
+        tokio::spawn(async move {
+            let _permit = permit;
+            let result =
+                handle_inbound(peer, stream.compat(), &http, &settings, &limiter, &metrics).await;
+            if let Err(e) = result {
+                debug!("fetch: inbound stream from {} failed: {}", peer, e);
+            }
+            let mut counts = per_peer.lock().await;
+            if let Some(count) = counts.get_mut(&peer) {
+                *count -= 1;
+                if *count == 0 {
+                    counts.remove(&peer);
+                }
+            }
+        });
+    }
+    warn!("fetch provider: incoming stream source closed");
+}
+
+pub async fn handle_inbound<S>(
+    peer: PeerId,
+    mut stream: S,
+    http: &reqwest::Client,
+    settings: &ProviderSettings,
+    limiter: &Arc<Mutex<ByteRateLimiter>>,
+    metrics: &Metrics,
+) -> std::io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let request: FetchRequest = timeout(REQUEST_READ_TIMEOUT, read_frame(&mut stream))
+        .await
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::TimedOut, "request read timeout"))??;
+
+    let not_found = FetchResponseHeader {
+        found: false,
+        size: 0,
+    };
+
+    if !is_valid_item_hash(&request.item_hash) || request.offset != 0 {
+        metrics.increment_event("fetch_serve_not_found");
+        return write_frame(&mut stream, &not_found).await;
+    }
+    let Some(base_url) = &settings.provider_url else {
+        metrics.increment_event("fetch_serve_not_found");
+        return write_frame(&mut stream, &not_found).await;
+    };
+
+    let url = format!(
+        "{}/api/v0/storage/raw/{}",
+        base_url.trim_end_matches('/'),
+        request.item_hash
+    );
+    let response = match http.get(&url).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            debug!(
+                "fetch: backend request failed for {}: {}",
+                request.item_hash, e
+            );
+            metrics.increment_event("fetch_serve_backend_error");
+            metrics.fetch_serve_errors_total.inc();
+            return write_frame(&mut stream, &not_found).await;
+        }
+    };
+
+    let size = match response.content_length() {
+        Some(size) if response.status().is_success() && size <= settings.max_size_bytes => size,
+        _ => {
+            metrics.increment_event(if response.status().is_success() {
+                "fetch_serve_not_found"
+            } else {
+                "fetch_serve_backend_error"
+            });
+            metrics.fetch_serve_errors_total.inc();
+            return write_frame(&mut stream, &not_found).await;
+        }
+    };
+
+    write_frame(&mut stream, &FetchResponseHeader { found: true, size }).await?;
+
+    let mut sent: u64 = 0;
+    let mut body = response.bytes_stream();
+    while let Some(chunk) = body.next().await {
+        let chunk = chunk.map_err(|e| std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e))?;
+        if sent + chunk.len() as u64 > size {
+            // Backend lied about Content-Length; cut the stream, the peer
+            // notices the mismatch against the announced size.
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "backend served more bytes than announced",
+            ));
+        }
+        limiter.lock().await.acquire(chunk.len()).await;
+        stream.write_all(&chunk).await?;
+        sent += chunk.len() as u64;
+        metrics.fetch_bytes_served_total.inc_by(chunk.len() as u64);
+    }
+    if sent != size {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "backend served fewer bytes than announced",
+        ));
+    }
+    stream.flush().await?;
+    metrics.fetch_served_total.inc();
+    debug!(
+        "fetch: served {} ({} bytes) to {}",
+        request.item_hash, sent, peer
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncReadExt;
+
+    /// Serves HTTP requests: 200 with `content` for /api/v0/storage/raw/<known_hash>,
+    /// 404 otherwise. Closes the connection after responding.
+    async fn mock_backend(known_hash: String, content: Vec<u8>) -> std::net::SocketAddr {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    return;
+                };
+                let known_hash = known_hash.clone();
+                let content = content.clone();
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 4096];
+                    let n = socket.read(&mut buf).await.unwrap_or(0);
+                    let request = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let response = if request.contains(&known_hash) {
+                        let mut r = format!(
+                            "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                            content.len()
+                        )
+                        .into_bytes();
+                        r.extend_from_slice(&content);
+                        r
+                    } else {
+                        b"HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+                            .to_vec()
+                    };
+                    let _ = tokio::io::AsyncWriteExt::write_all(&mut socket, &response).await;
+                });
+            }
+        });
+        addr
+    }
+
+    fn settings(provider_url: Option<String>) -> ProviderSettings {
+        ProviderSettings {
+            provider_url,
+            max_size_bytes: 1024 * 1024,
+            max_inbound_streams: 4,
+            max_inbound_streams_per_peer: 2,
+            serve_bytes_per_sec: 0,
+        }
+    }
+
+    async fn run_handler(
+        settings: ProviderSettings,
+        request: FetchRequest,
+    ) -> (FetchResponseHeader, Vec<u8>) {
+        let (provider_io, mut requester_io) = tokio::io::duplex(1024 * 1024);
+        let http = reqwest::Client::new();
+        let limiter = Arc::new(Mutex::new(ByteRateLimiter::new(
+            settings.serve_bytes_per_sec,
+        )));
+        let metrics = Metrics::new();
+        let handle = tokio::spawn(async move {
+            let _ = handle_inbound(
+                PeerId::random(),
+                provider_io,
+                &http,
+                &settings,
+                &limiter,
+                &metrics,
+            )
+            .await;
+        });
+        write_frame(&mut requester_io, &request).await.unwrap();
+        let header: FetchResponseHeader = read_frame(&mut requester_io).await.unwrap();
+        let mut body = Vec::new();
+        if header.found {
+            let mut chunk = vec![0u8; header.size as usize];
+            tokio::io::AsyncReadExt::read_exact(&mut requester_io, &mut chunk)
+                .await
+                .unwrap();
+            body = chunk;
+        }
+        handle.await.unwrap();
+        (header, body)
+    }
+
+    #[tokio::test]
+    async fn serves_known_content() {
+        let hash = "a".repeat(64);
+        let content = b"hello fetch protocol".to_vec();
+        let addr = mock_backend(hash.clone(), content.clone()).await;
+        let settings = settings(Some(format!("http://{}", addr)));
+        let (header, body) = run_handler(
+            settings,
+            FetchRequest {
+                item_hash: hash,
+                offset: 0,
+            },
+        )
+        .await;
+        assert!(header.found);
+        assert_eq!(header.size, content.len() as u64);
+        assert_eq!(body, content);
+    }
+
+    #[tokio::test]
+    async fn unknown_hash_is_not_found() {
+        let addr = mock_backend("a".repeat(64), b"x".to_vec()).await;
+        let settings = settings(Some(format!("http://{}", addr)));
+        let (header, _) = run_handler(
+            settings,
+            FetchRequest {
+                item_hash: "b".repeat(64),
+                offset: 0,
+            },
+        )
+        .await;
+        assert!(!header.found);
+    }
+
+    #[tokio::test]
+    async fn disabled_provider_answers_not_found() {
+        let (header, _) = run_handler(
+            settings(None),
+            FetchRequest {
+                item_hash: "a".repeat(64),
+                offset: 0,
+            },
+        )
+        .await;
+        assert!(!header.found);
+    }
+
+    #[tokio::test]
+    async fn oversized_content_is_refused() {
+        let hash = "a".repeat(64);
+        let content = vec![0u8; 4096];
+        let addr = mock_backend(hash.clone(), content).await;
+        let mut s = settings(Some(format!("http://{}", addr)));
+        s.max_size_bytes = 1024;
+        let (header, _) = run_handler(
+            s,
+            FetchRequest {
+                item_hash: hash,
+                offset: 0,
+            },
+        )
+        .await;
+        assert!(!header.found);
+    }
+
+    #[tokio::test]
+    async fn invalid_hash_is_refused_without_backend_call() {
+        let settings = settings(Some("http://127.0.0.1:1".to_string()));
+        let (header, _) = run_handler(
+            settings,
+            FetchRequest {
+                item_hash: "../../etc/passwd".to_string(),
+                offset: 0,
+            },
+        )
+        .await;
+        assert!(!header.found);
+    }
+}

--- a/src/fetch/provider.rs
+++ b/src/fetch/provider.rs
@@ -23,7 +23,23 @@ use crate::fetch::wire::{read_frame, write_frame, FetchRequest, FetchResponseHea
 use crate::metrics::Metrics;
 
 const REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(10);
-const BACKEND_TIMEOUT: Duration = Duration::from_secs(60);
+/// Per-write timeout towards the remote peer. Without it, a requester that
+/// stops reading stalls write_all forever once the mux send window fills,
+/// holding its serving slot indefinitely.
+const SERVE_WRITE_TIMEOUT: Duration = Duration::from_secs(30);
+const BACKEND_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+/// Inactivity timeout on backend reads. A total request timeout would cap
+/// large transfers, since the body relay is paced by the remote peer.
+const BACKEND_READ_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Wraps a write towards the remote peer in SERVE_WRITE_TIMEOUT.
+async fn timed<T>(
+    fut: impl std::future::Future<Output = std::io::Result<T>>,
+) -> std::io::Result<T> {
+    timeout(SERVE_WRITE_TIMEOUT, fut)
+        .await
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::TimedOut, "peer write timeout"))?
+}
 
 #[derive(Clone)]
 pub struct ProviderSettings {
@@ -81,7 +97,8 @@ pub async fn run(
     metrics: Metrics,
 ) {
     let http = reqwest::Client::builder()
-        .timeout(BACKEND_TIMEOUT)
+        .connect_timeout(BACKEND_CONNECT_TIMEOUT)
+        .read_timeout(BACKEND_READ_TIMEOUT)
         .build()
         .expect("reqwest client construction cannot fail with static settings");
     let global_slots = Arc::new(Semaphore::new(settings.max_inbound_streams));
@@ -152,11 +169,11 @@ where
 
     if !is_valid_item_hash(&request.item_hash) || request.offset != 0 {
         metrics.increment_event("fetch_serve_not_found");
-        return write_frame(&mut stream, &not_found).await;
+        return timed(write_frame(&mut stream, &not_found)).await;
     }
     let Some(base_url) = &settings.provider_url else {
         metrics.increment_event("fetch_serve_not_found");
-        return write_frame(&mut stream, &not_found).await;
+        return timed(write_frame(&mut stream, &not_found)).await;
     };
 
     let url = format!(
@@ -173,7 +190,7 @@ where
             );
             metrics.increment_event("fetch_serve_backend_error");
             metrics.fetch_serve_errors_total.inc();
-            return write_frame(&mut stream, &not_found).await;
+            return timed(write_frame(&mut stream, &not_found)).await;
         }
     };
 
@@ -186,11 +203,15 @@ where
                 "fetch_serve_backend_error"
             });
             metrics.fetch_serve_errors_total.inc();
-            return write_frame(&mut stream, &not_found).await;
+            return timed(write_frame(&mut stream, &not_found)).await;
         }
     };
 
-    write_frame(&mut stream, &FetchResponseHeader { found: true, size }).await?;
+    timed(write_frame(
+        &mut stream,
+        &FetchResponseHeader { found: true, size },
+    ))
+    .await?;
 
     let mut sent: u64 = 0;
     let mut body = response.bytes_stream();
@@ -205,7 +226,7 @@ where
             ));
         }
         limiter.lock().await.acquire(chunk.len()).await;
-        stream.write_all(&chunk).await?;
+        timed(stream.write_all(&chunk)).await?;
         sent += chunk.len() as u64;
         metrics.fetch_bytes_served_total.inc_by(chunk.len() as u64);
     }
@@ -215,7 +236,7 @@ where
             "backend served fewer bytes than announced",
         ));
     }
-    stream.flush().await?;
+    timed(stream.flush()).await?;
     metrics.fetch_served_total.inc();
     debug!(
         "fetch: served {} ({} bytes) to {}",

--- a/src/fetch/provider.rs
+++ b/src/fetch/provider.rs
@@ -1,15 +1,50 @@
 //! Provider side of the `/aleph/fetch/1.0.0` protocol.
 //!
-//! The provider holds no storage: every inbound request is proxied to the
-//! local pyaleph API (`GET {content_provider_url}/api/v0/storage/raw/{hash}`)
-//! and the response body is relayed to the remote peer. Serving is disabled
-//! while `provider_url` is `None`; every request is then answered with
-//! `found: false` so old deployments keep working without config changes.
+//! Inbound fetch requests are resolved from local sources in this order:
+//!
+//! 1. **Filesystem** (`content_dir`): pyaleph stores content as flat files
+//!    named by their item hash directly in its storage folder. If the file
+//!    exists, is a regular file and does not exceed `max_size_bytes`, it is
+//!    streamed back to the requester.
+//!
+//! 2. **Local Kubo** (`ipfs_api_url`): if the item hash parses as a CID, the
+//!    local Kubo RPC is queried with `offline=true` on every call. This
+//!    parameter instructs Kubo to return an error instead of fetching the
+//!    block from the public IPFS network. Only blocks already resident in the
+//!    local blockstore are served. An error from Kubo (non-2xx, or the size
+//!    field missing) falls through to not-found.
+//!
+//! 3. **Not found**: the requester falls through to its own IPFS path. This
+//!    is the intended behavior for content that is not locally available.
+//!
+//! Serving is disabled when both `content_dir` and `ipfs_api_url` are `None`;
+//! every request is then answered with `found: false`.
+//!
+//! # Kubo locality guarantee
+//!
+//! The non-negotiable invariant is that an inbound fetch request must NEVER
+//! cause the local Kubo daemon to pull blocks off the public IPFS network.
+//!
+//! Both Kubo RPC calls in this module include `&offline=true`:
+//!   - `POST /api/v0/files/stat?arg=/ipfs/{cid}&offline=true` - checks the
+//!     size of the content. Returns an error when the block is not local.
+//!   - `POST /api/v0/cat?arg={cid}&offline=true` - streams the content bytes.
+//!
+//! The `offline=true` flag was introduced in Kubo 0.12 (released 2021-04-27)
+//! and is supported on all modern Kubo releases used in aleph.im deployments.
+//! When `offline=true` is set on `/api/v0/files/stat`, Kubo returns HTTP 500
+//! with a JSON error body if any referenced block is not in the local
+//! blockstore, rather than attempting a network fetch. We gate the `cat` call
+//! behind a successful `files/stat` response to ensure we never stream
+//! partially-local content. Only if `files/stat` succeeds (2xx + a `Size`
+//! field) do we proceed to `cat` (also with `offline=true`).
 
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use bytes::Bytes;
 use futures::StreamExt;
 use libp2p::PeerId;
 use log::{debug, warn};
@@ -17,6 +52,7 @@ use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::sync::{Mutex, Semaphore};
 use tokio::time::{timeout, Instant};
 use tokio_util::compat::FuturesAsyncReadCompatExt;
+use tokio_util::io::ReaderStream;
 
 use crate::fetch::is_valid_item_hash;
 use crate::fetch::wire::{read_frame, write_frame, FetchRequest, FetchResponseHeader};
@@ -32,6 +68,9 @@ const BACKEND_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// large transfers, since the body relay is paced by the remote peer.
 const BACKEND_READ_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Read buffer capacity for filesystem streaming.
+const FS_STREAM_CHUNK: usize = 64 * 1024;
+
 /// Wraps a write towards the remote peer in SERVE_WRITE_TIMEOUT.
 async fn timed<T>(
     fut: impl std::future::Future<Output = std::io::Result<T>>,
@@ -43,8 +82,10 @@ async fn timed<T>(
 
 #[derive(Clone)]
 pub struct ProviderSettings {
-    /// None disables serving (every request answered found=false).
-    pub provider_url: Option<String>,
+    /// `None` disables filesystem serving.
+    pub content_dir: Option<PathBuf>,
+    /// `None` disables Kubo/IPFS serving.
+    pub ipfs_api_url: Option<String>,
     pub max_size_bytes: u64,
     pub max_inbound_streams: usize,
     pub max_inbound_streams_per_peer: usize,
@@ -87,6 +128,130 @@ impl ByteRateLimiter {
             }
             let deficit = n as f64 - self.available;
             tokio::time::sleep(Duration::from_secs_f64(deficit / self.bytes_per_sec as f64)).await;
+        }
+    }
+}
+
+/// Resolved content: a known byte size and a stream of raw bytes.
+type ContentStream = std::pin::Pin<Box<dyn futures::Stream<Item = std::io::Result<Bytes>> + Send>>;
+
+/// Try to resolve the content from the local filesystem.
+///
+/// Returns `Some((size, stream))` if the file exists, is a regular file, and
+/// does not exceed `max_size_bytes`. Returns `None` when the file is not
+/// found. Returns `Err` when the file exists but exceeds the size limit
+/// (caller should record a refused metric).
+async fn resolve_from_fs(
+    content_dir: &Path,
+    item_hash: &str,
+    max_size_bytes: u64,
+) -> std::io::Result<Option<(u64, ContentStream)>> {
+    let path = content_dir.join(item_hash);
+    let meta = match tokio::fs::metadata(&path).await {
+        Ok(m) => m,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e),
+    };
+    if !meta.is_file() {
+        return Ok(None);
+    }
+    let size = meta.len();
+    if size > max_size_bytes {
+        // Signal "exists but too large" with a specific error kind.
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::FileTooLarge,
+            format!(
+                "content file {} is {} bytes, exceeds max {}",
+                item_hash, size, max_size_bytes
+            ),
+        ));
+    }
+    let file = tokio::fs::File::open(&path).await?;
+    let stream: ContentStream = Box::pin(ReaderStream::with_capacity(file, FS_STREAM_CHUNK));
+    Ok(Some((size, stream)))
+}
+
+/// Query Kubo for file size via `files/stat` with `offline=true`.
+///
+/// Returns the `Size` field on success, or `None` when Kubo returns an error
+/// (non-2xx) or the block is not local.
+async fn kubo_stat_local(http: &reqwest::Client, ipfs_api_url: &str, cid_str: &str) -> Option<u64> {
+    let url = format!(
+        "{}/api/v0/files/stat?arg=/ipfs/{}&offline=true",
+        ipfs_api_url.trim_end_matches('/'),
+        cid_str
+    );
+    let resp = http.post(&url).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let json: serde_json::Value = resp.json().await.ok()?;
+    json["Size"].as_u64()
+}
+
+/// Stream content from Kubo via `cat` with `offline=true`.
+async fn kubo_cat_local(
+    http: &reqwest::Client,
+    ipfs_api_url: &str,
+    cid_str: &str,
+) -> std::io::Result<ContentStream> {
+    let url = format!(
+        "{}/api/v0/cat?arg={}&offline=true",
+        ipfs_api_url.trim_end_matches('/'),
+        cid_str
+    );
+    let resp = http
+        .post(&url)
+        .send()
+        .await
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::ConnectionRefused, e))?;
+    if !resp.status().is_success() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("Kubo cat returned {}", resp.status()),
+        ));
+    }
+    let stream: ContentStream = Box::pin(
+        resp.bytes_stream()
+            .map(|r| r.map_err(|e| std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e))),
+    );
+    Ok(stream)
+}
+
+/// Resolve content from Kubo (local-only).
+///
+/// Returns `Some((size, stream))` if the CID is locally available in Kubo and
+/// does not exceed `max_size_bytes`. Returns `None` when the block is not
+/// local, Kubo is unavailable, or the size exceeds the limit.
+async fn resolve_from_ipfs(
+    http: &reqwest::Client,
+    ipfs_api_url: &str,
+    item_hash: &str,
+    max_size_bytes: u64,
+) -> Option<(u64, ContentStream)> {
+    // Only proceed if the hash parses as a CID.
+    if item_hash.parse::<cid::Cid>().is_err() {
+        return None;
+    }
+
+    // Query Kubo for the local size. `offline=true` ensures this errors
+    // instead of fetching from the network when the block is not local.
+    let size = kubo_stat_local(http, ipfs_api_url, item_hash).await?;
+    if size > max_size_bytes {
+        debug!(
+            "fetch: IPFS CID {} is {} bytes, exceeds max {}; refusing",
+            item_hash, size, max_size_bytes
+        );
+        return None;
+    }
+
+    // Size is acceptable; stream the content. Also with `offline=true` to
+    // ensure locality throughout.
+    match kubo_cat_local(http, ipfs_api_url, item_hash).await {
+        Ok(stream) => Some((size, stream)),
+        Err(e) => {
+            debug!("fetch: Kubo cat failed for {}: {}", item_hash, e);
+            None
         }
     }
 }
@@ -167,42 +332,20 @@ where
         size: 0,
     };
 
+    // Validate hash: guards both protocol correctness and path traversal.
+    // is_valid_item_hash allows only ASCII alphanumeric chars, so a hash
+    // accepted here can be safely appended to a filesystem path.
     if !is_valid_item_hash(&request.item_hash) || request.offset != 0 {
         metrics.increment_event("fetch_serve_not_found");
         return timed(write_frame(&mut stream, &not_found)).await;
     }
-    let Some(base_url) = &settings.provider_url else {
-        metrics.increment_event("fetch_serve_not_found");
-        return timed(write_frame(&mut stream, &not_found)).await;
-    };
 
-    let url = format!(
-        "{}/api/v0/storage/raw/{}",
-        base_url.trim_end_matches('/'),
-        request.item_hash
-    );
-    let response = match http.get(&url).send().await {
-        Ok(r) => r,
-        Err(e) => {
-            debug!(
-                "fetch: backend request failed for {}: {}",
-                request.item_hash, e
-            );
-            metrics.increment_event("fetch_serve_backend_error");
-            metrics.fetch_serve_errors_total.inc();
-            return timed(write_frame(&mut stream, &not_found)).await;
-        }
-    };
+    // Attempt to resolve content from local sources.
+    let resolved = resolve_content(http, settings, &request.item_hash, metrics).await;
 
-    let size = match response.content_length() {
-        Some(size) if response.status().is_success() && size <= settings.max_size_bytes => size,
-        _ => {
-            metrics.increment_event(if response.status().is_success() {
-                "fetch_serve_not_found"
-            } else {
-                "fetch_serve_backend_error"
-            });
-            metrics.fetch_serve_errors_total.inc();
+    let (size, body) = match resolved {
+        Some(pair) => pair,
+        None => {
             return timed(write_frame(&mut stream, &not_found)).await;
         }
     };
@@ -214,15 +357,15 @@ where
     .await?;
 
     let mut sent: u64 = 0;
-    let mut body = response.bytes_stream();
+    futures::pin_mut!(body);
     while let Some(chunk) = body.next().await {
         let chunk = chunk.map_err(|e| std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e))?;
         if sent + chunk.len() as u64 > size {
-            // Backend lied about Content-Length; cut the stream, the peer
-            // notices the mismatch against the announced size.
+            // Source lied about the size; cut the stream so the peer notices
+            // the mismatch against the announced size.
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
-                "backend served more bytes than announced",
+                "source served more bytes than announced",
             ));
         }
         limiter.lock().await.acquire(chunk.len()).await;
@@ -233,7 +376,7 @@ where
     if sent != size {
         return Err(std::io::Error::new(
             std::io::ErrorKind::UnexpectedEof,
-            "backend served fewer bytes than announced",
+            "source served fewer bytes than announced",
         ));
     }
     timed(stream.flush()).await?;
@@ -243,6 +386,51 @@ where
         request.item_hash, sent, peer
     );
     Ok(())
+}
+
+/// Resolve content from local sources (filesystem then Kubo).
+///
+/// Returns `Some((size, stream))` on success, `None` on miss.
+/// Increments the appropriate metric on misses.
+async fn resolve_content(
+    http: &reqwest::Client,
+    settings: &ProviderSettings,
+    item_hash: &str,
+    metrics: &Metrics,
+) -> Option<(u64, ContentStream)> {
+    // 1. Filesystem
+    if let Some(content_dir) = &settings.content_dir {
+        match resolve_from_fs(content_dir, item_hash, settings.max_size_bytes).await {
+            Ok(Some(pair)) => return Some(pair),
+            Ok(None) => {} // not on FS; fall through
+            Err(e) if e.kind() == std::io::ErrorKind::FileTooLarge => {
+                // File present but oversized; treat as refused.
+                debug!(
+                    "fetch: {} exceeds max_size_bytes on filesystem, refusing",
+                    item_hash
+                );
+                metrics.increment_event("fetch_serve_not_found");
+                return None;
+            }
+            Err(e) => {
+                debug!("fetch: filesystem read error for {}: {}", item_hash, e);
+                // Fall through to IPFS.
+            }
+        }
+    }
+
+    // 2. Local Kubo
+    if let Some(ipfs_api_url) = &settings.ipfs_api_url {
+        if let Some(pair) =
+            resolve_from_ipfs(http, ipfs_api_url, item_hash, settings.max_size_bytes).await
+        {
+            return Some(pair);
+        }
+    }
+
+    // 3. Not found
+    metrics.increment_event("fetch_serve_not_found");
+    None
 }
 
 #[cfg(test)]
@@ -257,49 +445,22 @@ mod tests {
         limiter.acquire(64 * 1024).await;
     }
 
-    /// Serves HTTP requests: 200 with `content` for /api/v0/storage/raw/<known_hash>,
-    /// 404 otherwise. Closes the connection after responding.
-    async fn mock_backend(known_hash: String, content: Vec<u8>) -> std::net::SocketAddr {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            loop {
-                let Ok((mut socket, _)) = listener.accept().await else {
-                    return;
-                };
-                let known_hash = known_hash.clone();
-                let content = content.clone();
-                tokio::spawn(async move {
-                    let mut buf = vec![0u8; 4096];
-                    let n = socket.read(&mut buf).await.unwrap_or(0);
-                    let request = String::from_utf8_lossy(&buf[..n]).to_string();
-                    let response = if request.contains(&known_hash) {
-                        let mut r = format!(
-                            "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
-                            content.len()
-                        )
-                        .into_bytes();
-                        r.extend_from_slice(&content);
-                        r
-                    } else {
-                        b"HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
-                            .to_vec()
-                    };
-                    let _ = tokio::io::AsyncWriteExt::write_all(&mut socket, &response).await;
-                });
-            }
-        });
-        addr
-    }
-
-    fn settings(provider_url: Option<String>) -> ProviderSettings {
+    fn settings_with(
+        content_dir: Option<PathBuf>,
+        ipfs_api_url: Option<String>,
+    ) -> ProviderSettings {
         ProviderSettings {
-            provider_url,
+            content_dir,
+            ipfs_api_url,
             max_size_bytes: 1024 * 1024,
             max_inbound_streams: 4,
             max_inbound_streams_per_peer: 2,
             serve_bytes_per_sec: 0,
         }
+    }
+
+    fn disabled_settings() -> ProviderSettings {
+        settings_with(None, None)
     }
 
     async fn run_handler(
@@ -337,12 +498,17 @@ mod tests {
         (header, body)
     }
 
+    // --- Filesystem tests ---
+
     #[tokio::test]
-    async fn serves_known_content() {
+    async fn fs_serves_known_content() {
+        let dir = tempfile::tempdir().unwrap();
         let hash = "a".repeat(64);
         let content = b"hello fetch protocol".to_vec();
-        let addr = mock_backend(hash.clone(), content.clone()).await;
-        let settings = settings(Some(format!("http://{}", addr)));
+        tokio::fs::write(dir.path().join(&hash), &content)
+            .await
+            .unwrap();
+        let settings = settings_with(Some(dir.path().to_path_buf()), None);
         let (header, body) = run_handler(
             settings,
             FetchRequest {
@@ -357,9 +523,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unknown_hash_is_not_found() {
-        let addr = mock_backend("a".repeat(64), b"x".to_vec()).await;
-        let settings = settings(Some(format!("http://{}", addr)));
+    async fn fs_unknown_hash_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings = settings_with(Some(dir.path().to_path_buf()), None);
         let (header, _) = run_handler(
             settings,
             FetchRequest {
@@ -372,27 +538,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn disabled_provider_answers_not_found() {
-        let (header, _) = run_handler(
-            settings(None),
-            FetchRequest {
-                item_hash: "a".repeat(64),
-                offset: 0,
-            },
-        )
-        .await;
-        assert!(!header.found);
-    }
-
-    #[tokio::test]
-    async fn oversized_content_is_refused() {
+    async fn fs_oversized_refused() {
+        let dir = tempfile::tempdir().unwrap();
         let hash = "a".repeat(64);
         let content = vec![0u8; 4096];
-        let addr = mock_backend(hash.clone(), content).await;
-        let mut s = settings(Some(format!("http://{}", addr)));
-        s.max_size_bytes = 1024;
+        tokio::fs::write(dir.path().join(&hash), &content)
+            .await
+            .unwrap();
+        let mut settings = settings_with(Some(dir.path().to_path_buf()), None);
+        settings.max_size_bytes = 1024;
         let (header, _) = run_handler(
-            s,
+            settings,
             FetchRequest {
                 item_hash: hash,
                 offset: 0,
@@ -403,8 +559,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invalid_hash_is_refused_without_backend_call() {
-        let settings = settings(Some("http://127.0.0.1:1".to_string()));
+    async fn provider_disabled_not_found() {
+        let (header, _) = run_handler(
+            disabled_settings(),
+            FetchRequest {
+                item_hash: "a".repeat(64),
+                offset: 0,
+            },
+        )
+        .await;
+        assert!(!header.found);
+    }
+
+    #[tokio::test]
+    async fn invalid_hash_refused() {
+        // Path traversal attempt: is_valid_item_hash must reject this.
+        let dir = tempfile::tempdir().unwrap();
+        let settings = settings_with(Some(dir.path().to_path_buf()), None);
         let (header, _) = run_handler(
             settings,
             FetchRequest {
@@ -414,5 +585,186 @@ mod tests {
         )
         .await;
         assert!(!header.found);
+    }
+
+    // --- Mock Kubo HTTP server ---
+
+    /// A minimal HTTP server that handles Kubo RPC requests.
+    ///
+    /// `files_stat_response`: if `Some(size)`, files/stat returns 200 + JSON
+    /// `{"Size": size}`; if `None`, returns 500.
+    /// `cat_body`: the body to return for cat requests (200 OK).
+    /// Returns (addr, hit_count_arc).
+    async fn mock_kubo(
+        known_cid: String,
+        files_stat_response: Option<u64>,
+        cat_body: Vec<u8>,
+        hit_counter: Arc<std::sync::Mutex<usize>>,
+    ) -> std::net::SocketAddr {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    return;
+                };
+                let known_cid = known_cid.clone();
+                let files_stat_response = files_stat_response;
+                let cat_body = cat_body.clone();
+                let hit_counter = hit_counter.clone();
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 8192];
+                    let n = socket.read(&mut buf).await.unwrap_or(0);
+                    let request = String::from_utf8_lossy(&buf[..n]).to_string();
+                    *hit_counter.lock().unwrap() += 1;
+
+                    let response = if request.contains("files/stat") && request.contains(&known_cid)
+                    {
+                        match files_stat_response {
+                            Some(size) => {
+                                let body = format!(r#"{{"Size":{}}}"#, size);
+                                format!(
+                                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                                    body.len(), body
+                                ).into_bytes()
+                            }
+                            None => b"HTTP/1.1 500 Internal Server Error\r\ncontent-length: 0\r\nconnection: close\r\n\r\n".to_vec(),
+                        }
+                    } else if request.contains("/api/v0/cat") && request.contains(&known_cid) {
+                        let mut r = format!(
+                            "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                            cat_body.len()
+                        )
+                        .into_bytes();
+                        r.extend_from_slice(&cat_body);
+                        r
+                    } else {
+                        b"HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+                            .to_vec()
+                    };
+                    let _ = tokio::io::AsyncWriteExt::write_all(&mut socket, &response).await;
+                });
+            }
+        });
+        addr
+    }
+
+    // A known-good CIDv0 (empty-directory CID used by IPFS docs as a stable example).
+    const KNOWN_CIDV0: &str = "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn";
+
+    #[tokio::test]
+    async fn ipfs_serves_cid_when_local() {
+        let content = b"ipfs content bytes".to_vec();
+        let hit_counter = Arc::new(std::sync::Mutex::new(0usize));
+        let addr = mock_kubo(
+            KNOWN_CIDV0.to_string(),
+            Some(content.len() as u64),
+            content.clone(),
+            hit_counter.clone(),
+        )
+        .await;
+        let settings = settings_with(None, Some(format!("http://{}", addr)));
+        let (header, body) = run_handler(
+            settings,
+            FetchRequest {
+                item_hash: KNOWN_CIDV0.to_string(),
+                offset: 0,
+            },
+        )
+        .await;
+        assert!(header.found, "expected found=true");
+        assert_eq!(header.size, content.len() as u64);
+        assert_eq!(body, content);
+    }
+
+    #[tokio::test]
+    async fn ipfs_not_local_not_found() {
+        let hit_counter = Arc::new(std::sync::Mutex::new(0usize));
+        let addr = mock_kubo(
+            KNOWN_CIDV0.to_string(),
+            None, // files/stat returns 500 (not local)
+            vec![],
+            hit_counter.clone(),
+        )
+        .await;
+        let settings = settings_with(None, Some(format!("http://{}", addr)));
+        let (header, _) = run_handler(
+            settings,
+            FetchRequest {
+                item_hash: KNOWN_CIDV0.to_string(),
+                offset: 0,
+            },
+        )
+        .await;
+        assert!(!header.found);
+    }
+
+    #[tokio::test]
+    async fn non_cid_hash_never_calls_kubo() {
+        // A 64-hex hash does not parse as a CID; Kubo must never be contacted.
+        let hit_counter = Arc::new(std::sync::Mutex::new(0usize));
+        let addr = mock_kubo(
+            "dummy".to_string(),
+            Some(100),
+            vec![0u8; 100],
+            hit_counter.clone(),
+        )
+        .await;
+        let settings = settings_with(None, Some(format!("http://{}", addr)));
+        let (header, _) = run_handler(
+            settings,
+            FetchRequest {
+                item_hash: "a".repeat(64),
+                offset: 0,
+            },
+        )
+        .await;
+        assert!(!header.found);
+        // Give any errant background tasks a moment to reach the server.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            *hit_counter.lock().unwrap(),
+            0,
+            "Kubo must not be contacted for a non-CID hash"
+        );
+    }
+
+    #[tokio::test]
+    async fn fs_precedence_over_ipfs() {
+        // A file present on FS whose name parses as a CID is served from FS;
+        // Kubo must not be contacted.
+        let dir = tempfile::tempdir().unwrap();
+        let content = b"from filesystem".to_vec();
+        tokio::fs::write(dir.path().join(KNOWN_CIDV0), &content)
+            .await
+            .unwrap();
+        let hit_counter = Arc::new(std::sync::Mutex::new(0usize));
+        let addr = mock_kubo(
+            KNOWN_CIDV0.to_string(),
+            Some(999),
+            b"from kubo".to_vec(),
+            hit_counter.clone(),
+        )
+        .await;
+        let settings = settings_with(
+            Some(dir.path().to_path_buf()),
+            Some(format!("http://{}", addr)),
+        );
+        let (header, body) = run_handler(
+            settings,
+            FetchRequest {
+                item_hash: KNOWN_CIDV0.to_string(),
+                offset: 0,
+            },
+        )
+        .await;
+        assert!(header.found);
+        assert_eq!(body, content, "content must come from FS, not Kubo");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            *hit_counter.lock().unwrap(),
+            0,
+            "Kubo must not be contacted when FS has the content"
+        );
     }
 }

--- a/src/fetch/requester.rs
+++ b/src/fetch/requester.rs
@@ -109,6 +109,11 @@ pub async fn fetch_from_peers(
                 cooldowns.penalize(peer);
                 return Err(FetchError::Aborted(reason));
             }
+            Err(TryPeerError::ConsumerGone) => {
+                // Our gRPC consumer went away; the serving peer did nothing
+                // wrong, so it is not penalized.
+                return Err(FetchError::Aborted("consumer went away".into()));
+            }
         }
     }
     Err(FetchError::NotFound)
@@ -122,8 +127,12 @@ enum PeerOutcome {
 enum TryPeerError {
     /// Nothing was forwarded to the caller yet; the next peer can be tried.
     Retryable(String),
-    /// Content bytes were already forwarded; the fetch must abort.
+    /// Content bytes were already forwarded and the peer is at fault;
+    /// the fetch must abort.
     Fatal(String),
+    /// Content bytes were already forwarded but our own consumer dropped
+    /// the channel; the fetch must abort without penalizing the peer.
+    ConsumerGone,
 }
 
 async fn try_peer(
@@ -180,7 +189,7 @@ async fn try_peer(
     // From the first forwarded byte on, failures are fatal for this RPC.
     tx.send(FetchProgress::Header { size: header.size })
         .await
-        .map_err(|_| TryPeerError::Fatal("consumer went away".into()))?;
+        .map_err(|_| TryPeerError::ConsumerGone)?;
 
     let mut remaining = header.size;
     let mut buf = vec![0u8; CHUNK_SIZE];
@@ -199,7 +208,7 @@ async fn try_peer(
         metrics.fetch_bytes_fetched_total.inc_by(to_read as u64);
         tx.send(FetchProgress::Chunk(buf[..to_read].to_vec()))
             .await
-            .map_err(|_| TryPeerError::Fatal("consumer went away".into()))?;
+            .map_err(|_| TryPeerError::ConsumerGone)?;
         remaining -= to_read as u64;
     }
     Ok(PeerOutcome::Served)

--- a/src/fetch/requester.rs
+++ b/src/fetch/requester.rs
@@ -105,6 +105,13 @@ pub async fn fetch_from_peers(
                 metrics.increment_event("fetch_peer_error");
                 cooldowns.penalize(peer);
             }
+            Err(TryPeerError::SkipNoPenalty(reason)) => {
+                debug!(
+                    "fetch: skipping peer {} for {}: {}",
+                    peer, item_hash, reason
+                );
+                metrics.increment_event("fetch_peer_skipped");
+            }
             Err(TryPeerError::Fatal(reason)) => {
                 cooldowns.penalize(peer);
                 return Err(FetchError::Aborted(reason));
@@ -127,6 +134,9 @@ enum PeerOutcome {
 enum TryPeerError {
     /// Nothing was forwarded to the caller yet; the next peer can be tried.
     Retryable(String),
+    /// Nothing was forwarded and the failure was not the peer's fault
+    /// (e.g. we could not even reach it); try the next peer, no cooldown.
+    SkipNoPenalty(String),
     /// Content bytes were already forwarded and the peer is at fault;
     /// the fetch must abort.
     Fatal(String),
@@ -145,13 +155,25 @@ async fn try_peer(
 ) -> Result<PeerOutcome, TryPeerError> {
     let retryable = TryPeerError::Retryable;
 
-    let stream = timeout(
+    let stream = match timeout(
         settings.peer_timeout,
         control.open_stream(peer, FETCH_PROTOCOL),
     )
     .await
-    .map_err(|_| retryable("open timeout".into()))?
-    .map_err(|e| retryable(format!("open failed: {}", e)))?;
+    {
+        Err(_) => return Err(retryable("open timeout".into())),
+        Ok(Err(libp2p_stream::OpenStreamError::UnsupportedProtocol(_))) => {
+            // A peer without fetch support; cool it down so transition-era fetches do
+            // not burn their attempts on old nodes on every RPC.
+            return Err(retryable("fetch protocol unsupported".into()));
+        }
+        Ok(Err(e)) => {
+            // Typically a dial failure for a hinted peer we are not
+            // connected to; not the peer's fault, skip without penalty.
+            return Err(TryPeerError::SkipNoPenalty(format!("open failed: {}", e)));
+        }
+        Ok(Ok(stream)) => stream,
+    };
     let mut stream = stream.compat();
 
     timeout(
@@ -284,6 +306,7 @@ mod tests {
         };
         let cooldowns = FetchCooldowns::default();
         let (tx, _rx) = mpsc::channel(16);
+        let metrics = Metrics::new();
 
         let result = fetch_from_peers(
             control,
@@ -291,19 +314,25 @@ mod tests {
             "a".repeat(64),
             settings,
             &cooldowns,
-            Metrics::new(),
+            metrics.clone(),
             tx,
         )
         .await;
         assert!(matches!(result, Err(FetchError::NotFound)));
 
-        // Only the first two candidates were attempted (and penalized);
-        // the attempt cap stopped the loop before the rest.
-        assert!(cooldowns.is_cooling(&candidates[0]));
-        assert!(cooldowns.is_cooling(&candidates[1]));
-        assert!(!cooldowns.is_cooling(&candidates[2]));
-        assert!(!cooldowns.is_cooling(&candidates[3]));
-        assert!(!cooldowns.is_cooling(&candidates[4]));
+        // Only the first two candidates were attempted; the attempt cap
+        // stopped the loop before the rest. Unreachable peers are skipped
+        // without a cooldown penalty (it is not the peer's fault).
+        let skipped = metrics
+            .p2p_events
+            .get_or_create(&crate::metrics::EventLabel {
+                event_type: "fetch_peer_skipped".to_string(),
+            })
+            .get();
+        assert_eq!(skipped, 2);
+        for candidate in &candidates {
+            assert!(!cooldowns.is_cooling(candidate));
+        }
     }
 
     #[tokio::test]
@@ -336,6 +365,7 @@ mod tests {
             max_peer_attempts: 1,
         };
         let (tx, _rx) = mpsc::channel(16);
+        let metrics = Metrics::new();
 
         let result = fetch_from_peers(
             control,
@@ -343,14 +373,22 @@ mod tests {
             "a".repeat(64),
             settings,
             &cooldowns,
-            Metrics::new(),
+            metrics.clone(),
             tx,
         )
         .await;
         assert!(matches!(result, Err(FetchError::NotFound)));
 
-        // The two cooling peers were skipped; the single attempt went to the
-        // third candidate, which then failed and was penalized.
-        assert!(cooldowns.is_cooling(&candidates[2]));
+        // The two cooling peers were skipped without consuming the single
+        // attempt, which went to the third candidate. Being unreachable,
+        // that candidate is skipped without a penalty.
+        let skipped = metrics
+            .p2p_events
+            .get_or_create(&crate::metrics::EventLabel {
+                event_type: "fetch_peer_skipped".to_string(),
+            })
+            .get();
+        assert_eq!(skipped, 1);
+        assert!(!cooldowns.is_cooling(&candidates[2]));
     }
 }

--- a/src/fetch/requester.rs
+++ b/src/fetch/requester.rs
@@ -1,0 +1,347 @@
+//! Requester side of the `/aleph/fetch/1.0.0` protocol.
+//!
+//! Tries candidate peers in order (gRPC caller hints first, then connected
+//! peers sorted preferred/score by the caller) with a per-peer timeout on
+//! every step and an attempt cap. Failed peers go into a cooldown map so the
+//! next fetch skips them. The content hash is verified by pyaleph, never
+//! here; this side only enforces the size limit.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use libp2p::PeerId;
+use log::debug;
+use tokio::io::AsyncReadExt;
+use tokio::sync::mpsc;
+use tokio::time::{timeout, Instant};
+use tokio_util::compat::FuturesAsyncReadCompatExt;
+
+use crate::fetch::wire::{read_frame, write_frame, FetchRequest, FetchResponseHeader, CHUNK_SIZE};
+use crate::fetch::FETCH_PROTOCOL;
+use crate::metrics::Metrics;
+
+const COOLDOWN: Duration = Duration::from_secs(60);
+
+#[derive(Clone)]
+pub struct FetchSettings {
+    pub peer_timeout: Duration,
+    pub max_size_bytes: u64,
+    pub max_peer_attempts: usize,
+}
+
+#[derive(Debug)]
+pub enum FetchError {
+    /// No peer could provide the content (all candidates tried or skipped).
+    NotFound,
+    /// Failed after content bytes were already forwarded; not retryable.
+    Aborted(String),
+}
+
+#[derive(Debug)]
+pub enum FetchProgress {
+    Header { size: u64 },
+    Chunk(Vec<u8>),
+}
+
+/// Peers that recently failed a fetch are skipped for COOLDOWN.
+/// This stands in for a gossipsub behaviour penalty, which the gossipsub
+/// API does not let us inject from the outside.
+#[derive(Default)]
+pub struct FetchCooldowns {
+    inner: Mutex<HashMap<PeerId, Instant>>,
+}
+
+impl FetchCooldowns {
+    pub fn is_cooling(&self, peer: &PeerId) -> bool {
+        let mut map = self.inner.lock().expect("cooldown lock poisoned");
+        match map.get(peer) {
+            Some(since) if since.elapsed() < COOLDOWN => true,
+            Some(_) => {
+                map.remove(peer);
+                false
+            }
+            None => false,
+        }
+    }
+
+    pub fn penalize(&self, peer: PeerId) {
+        self.inner
+            .lock()
+            .expect("cooldown lock poisoned")
+            .insert(peer, Instant::now());
+    }
+}
+
+/// Tries candidates in order until one serves the content. Chunks are
+/// forwarded through `tx` as they arrive. The caller enforces the total
+/// deadline by wrapping this future in a timeout.
+pub async fn fetch_from_peers(
+    control: libp2p_stream::Control,
+    candidates: Vec<PeerId>,
+    item_hash: String,
+    settings: FetchSettings,
+    cooldowns: &FetchCooldowns,
+    metrics: Metrics,
+    tx: mpsc::Sender<FetchProgress>,
+) -> Result<(), FetchError> {
+    let mut attempts = 0usize;
+    for peer in candidates {
+        if attempts >= settings.max_peer_attempts {
+            break;
+        }
+        if cooldowns.is_cooling(&peer) {
+            continue;
+        }
+        attempts += 1;
+        match try_peer(control.clone(), peer, &item_hash, &settings, &metrics, &tx).await {
+            Ok(PeerOutcome::Served) => return Ok(()),
+            Ok(PeerOutcome::NotFound) => {
+                // An honest miss; no penalty.
+                metrics.increment_event("fetch_peer_not_found");
+            }
+            Err(TryPeerError::Retryable(reason)) => {
+                debug!("fetch: peer {} failed for {}: {}", peer, item_hash, reason);
+                metrics.increment_event("fetch_peer_error");
+                cooldowns.penalize(peer);
+            }
+            Err(TryPeerError::Fatal(reason)) => {
+                cooldowns.penalize(peer);
+                return Err(FetchError::Aborted(reason));
+            }
+        }
+    }
+    Err(FetchError::NotFound)
+}
+
+enum PeerOutcome {
+    Served,
+    NotFound,
+}
+
+enum TryPeerError {
+    /// Nothing was forwarded to the caller yet; the next peer can be tried.
+    Retryable(String),
+    /// Content bytes were already forwarded; the fetch must abort.
+    Fatal(String),
+}
+
+async fn try_peer(
+    mut control: libp2p_stream::Control,
+    peer: PeerId,
+    item_hash: &str,
+    settings: &FetchSettings,
+    metrics: &Metrics,
+    tx: &mpsc::Sender<FetchProgress>,
+) -> Result<PeerOutcome, TryPeerError> {
+    let retryable = TryPeerError::Retryable;
+
+    let stream = timeout(
+        settings.peer_timeout,
+        control.open_stream(peer, FETCH_PROTOCOL),
+    )
+    .await
+    .map_err(|_| retryable("open timeout".into()))?
+    .map_err(|e| retryable(format!("open failed: {}", e)))?;
+    let mut stream = stream.compat();
+
+    timeout(
+        settings.peer_timeout,
+        write_frame(
+            &mut stream,
+            &FetchRequest {
+                item_hash: item_hash.to_string(),
+                offset: 0,
+            },
+        ),
+    )
+    .await
+    .map_err(|_| retryable("request write timeout".into()))?
+    .map_err(|e| retryable(format!("request write failed: {}", e)))?;
+
+    let header: FetchResponseHeader = timeout(settings.peer_timeout, read_frame(&mut stream))
+        .await
+        .map_err(|_| {
+            metrics.increment_event("fetch_peer_timeout");
+            retryable("header read timeout".into())
+        })?
+        .map_err(|e| retryable(format!("header read failed: {}", e)))?;
+
+    if !header.found {
+        return Ok(PeerOutcome::NotFound);
+    }
+    if header.size > settings.max_size_bytes {
+        return Err(retryable(format!(
+            "announced size {} over limit",
+            header.size
+        )));
+    }
+
+    // From the first forwarded byte on, failures are fatal for this RPC.
+    tx.send(FetchProgress::Header { size: header.size })
+        .await
+        .map_err(|_| TryPeerError::Fatal("consumer went away".into()))?;
+
+    let mut remaining = header.size;
+    let mut buf = vec![0u8; CHUNK_SIZE];
+    while remaining > 0 {
+        let to_read = remaining.min(CHUNK_SIZE as u64) as usize;
+        timeout(
+            settings.peer_timeout,
+            stream.read_exact(&mut buf[..to_read]),
+        )
+        .await
+        .map_err(|_| {
+            metrics.increment_event("fetch_peer_timeout");
+            TryPeerError::Fatal("chunk read timeout".into())
+        })?
+        .map_err(|e| TryPeerError::Fatal(format!("chunk read failed: {}", e)))?;
+        metrics.fetch_bytes_fetched_total.inc_by(to_read as u64);
+        tx.send(FetchProgress::Chunk(buf[..to_read].to_vec()))
+            .await
+            .map_err(|_| TryPeerError::Fatal("consumer went away".into()))?;
+        remaining -= to_read as u64;
+    }
+    Ok(PeerOutcome::Served)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::sync::Arc;
+
+    use libp2p::identity;
+
+    use crate::p2p::network::{self, NetworkSettings};
+    use crate::p2p::peerstore::PeerStore;
+    use crate::subscriptions::Subscriptions;
+
+    #[tokio::test]
+    async fn penalized_peer_is_cooling() {
+        let cooldowns = FetchCooldowns::default();
+        let peer = PeerId::random();
+        assert!(!cooldowns.is_cooling(&peer));
+        cooldowns.penalize(peer);
+        assert!(cooldowns.is_cooling(&peer));
+        // Other peers are unaffected.
+        assert!(!cooldowns.is_cooling(&PeerId::random()));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cooldown_expires() {
+        let cooldowns = FetchCooldowns::default();
+        let peer = PeerId::random();
+        cooldowns.penalize(peer);
+        assert!(cooldowns.is_cooling(&peer));
+
+        // Just before expiry the peer is still cooling.
+        tokio::time::advance(COOLDOWN - Duration::from_secs(1)).await;
+        assert!(cooldowns.is_cooling(&peer));
+
+        // After expiry the peer is usable again and the entry is dropped.
+        tokio::time::advance(Duration::from_secs(2)).await;
+        assert!(!cooldowns.is_cooling(&peer));
+        assert!(!cooldowns.is_cooling(&peer));
+    }
+
+    #[tokio::test]
+    async fn attempt_cap_limits_tried_peers() {
+        // A real Control needs a running swarm; opening a stream to a
+        // disconnected random peer fails fast (no known addresses) or hits
+        // the 100 ms per-peer timeout.
+        let (_client, event_loop, control) = network::new(
+            identity::Keypair::generate_ed25519(),
+            NetworkSettings {
+                low_water: 80,
+                high_water: 160,
+                per_subnet_cap: 4,
+                max_protected_share: 0.5,
+            },
+            HashSet::new(),
+            Metrics::new(),
+            Arc::new(Subscriptions::new(16)),
+            Arc::new(std::sync::Mutex::new(PeerStore::default())),
+        )
+        .await
+        .unwrap();
+        tokio::spawn(event_loop.run());
+
+        let candidates: Vec<PeerId> = (0..5).map(|_| PeerId::random()).collect();
+        let settings = FetchSettings {
+            peer_timeout: Duration::from_millis(100),
+            max_size_bytes: 1024,
+            max_peer_attempts: 2,
+        };
+        let cooldowns = FetchCooldowns::default();
+        let (tx, _rx) = mpsc::channel(16);
+
+        let result = fetch_from_peers(
+            control,
+            candidates.clone(),
+            "a".repeat(64),
+            settings,
+            &cooldowns,
+            Metrics::new(),
+            tx,
+        )
+        .await;
+        assert!(matches!(result, Err(FetchError::NotFound)));
+
+        // Only the first two candidates were attempted (and penalized);
+        // the attempt cap stopped the loop before the rest.
+        assert!(cooldowns.is_cooling(&candidates[0]));
+        assert!(cooldowns.is_cooling(&candidates[1]));
+        assert!(!cooldowns.is_cooling(&candidates[2]));
+        assert!(!cooldowns.is_cooling(&candidates[3]));
+        assert!(!cooldowns.is_cooling(&candidates[4]));
+    }
+
+    #[tokio::test]
+    async fn cooling_peers_are_skipped_without_consuming_attempts() {
+        let (_client, event_loop, control) = network::new(
+            identity::Keypair::generate_ed25519(),
+            NetworkSettings {
+                low_water: 80,
+                high_water: 160,
+                per_subnet_cap: 4,
+                max_protected_share: 0.5,
+            },
+            HashSet::new(),
+            Metrics::new(),
+            Arc::new(Subscriptions::new(16)),
+            Arc::new(std::sync::Mutex::new(PeerStore::default())),
+        )
+        .await
+        .unwrap();
+        tokio::spawn(event_loop.run());
+
+        let candidates: Vec<PeerId> = (0..3).map(|_| PeerId::random()).collect();
+        let cooldowns = FetchCooldowns::default();
+        cooldowns.penalize(candidates[0]);
+        cooldowns.penalize(candidates[1]);
+
+        let settings = FetchSettings {
+            peer_timeout: Duration::from_millis(100),
+            max_size_bytes: 1024,
+            max_peer_attempts: 1,
+        };
+        let (tx, _rx) = mpsc::channel(16);
+
+        let result = fetch_from_peers(
+            control,
+            candidates.clone(),
+            "a".repeat(64),
+            settings,
+            &cooldowns,
+            Metrics::new(),
+            tx,
+        )
+        .await;
+        assert!(matches!(result, Err(FetchError::NotFound)));
+
+        // The two cooling peers were skipped; the single attempt went to the
+        // third candidate, which then failed and was penalized.
+        assert!(cooldowns.is_cooling(&candidates[2]));
+    }
+}

--- a/src/fetch/wire.rs
+++ b/src/fetch/wire.rs
@@ -1,0 +1,123 @@
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::io;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+/// Content is streamed in chunks of this size after the response header.
+pub const CHUNK_SIZE: usize = 64 * 1024;
+/// CBOR header frames are tiny; anything bigger is a protocol violation.
+pub const MAX_FRAME_SIZE: u32 = 4096;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FetchRequest {
+    pub item_hash: String,
+    /// Reserved for future range requests; must be 0.
+    pub offset: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FetchResponseHeader {
+    pub found: bool,
+    pub size: u64,
+}
+
+pub async fn write_frame<W, T>(writer: &mut W, value: &T) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+    T: Serialize,
+{
+    let bytes = cbor4ii::serde::to_vec(Vec::new(), value)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    if bytes.len() > MAX_FRAME_SIZE as usize {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "frame too large",
+        ));
+    }
+    writer.write_u32(bytes.len() as u32).await?;
+    writer.write_all(&bytes).await?;
+    writer.flush().await
+}
+
+pub async fn read_frame<R, T>(reader: &mut R) -> io::Result<T>
+where
+    R: AsyncRead + Unpin,
+    T: DeserializeOwned,
+{
+    let len = reader.read_u32().await?;
+    if len > MAX_FRAME_SIZE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "frame too large",
+        ));
+    }
+    let mut buf = vec![0u8; len as usize];
+    reader.read_exact(&mut buf).await?;
+    cbor4ii::serde::from_slice(&buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn frame_roundtrip() {
+        let (mut a, mut b) = tokio::io::duplex(8192);
+        let request = FetchRequest {
+            item_hash: "ab".repeat(32),
+            offset: 0,
+        };
+        write_frame(&mut a, &request).await.unwrap();
+        let read: FetchRequest = read_frame(&mut b).await.unwrap();
+        assert_eq!(read, request);
+    }
+
+    #[tokio::test]
+    async fn header_roundtrip() {
+        let (mut a, mut b) = tokio::io::duplex(8192);
+        let header = FetchResponseHeader {
+            found: true,
+            size: 12345,
+        };
+        write_frame(&mut a, &header).await.unwrap();
+        let read: FetchResponseHeader = read_frame(&mut b).await.unwrap();
+        assert_eq!(read, header);
+    }
+
+    #[tokio::test]
+    async fn oversized_frame_is_rejected() {
+        let (mut a, mut b) = tokio::io::duplex(16384);
+        // Hand-craft a frame announcing more than MAX_FRAME_SIZE bytes.
+        tokio::io::AsyncWriteExt::write_u32(&mut a, MAX_FRAME_SIZE + 1)
+            .await
+            .unwrap();
+        let result: std::io::Result<FetchRequest> = read_frame(&mut b).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn truncated_frame_errors() {
+        let (mut a, mut b) = tokio::io::duplex(8192);
+        tokio::io::AsyncWriteExt::write_u32(&mut a, 100)
+            .await
+            .unwrap();
+        tokio::io::AsyncWriteExt::write_all(&mut a, &[0u8; 10])
+            .await
+            .unwrap();
+        drop(a);
+        let result: std::io::Result<FetchRequest> = read_frame(&mut b).await;
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn item_hash_validation() {
+        use crate::fetch::is_valid_item_hash;
+        assert!(is_valid_item_hash(&"a".repeat(64)));
+        assert!(is_valid_item_hash(
+            "QmZkurbY2G2hWay59yiTgQNaQxHSNzKZFt2jbnwJhQcKgV"
+        ));
+        assert!(!is_valid_item_hash(""));
+        assert!(!is_valid_item_hash("../etc/passwd"));
+        assert!(!is_valid_item_hash(&"a".repeat(129)));
+        assert!(!is_valid_item_hash("abc/def"));
+    }
+}

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -288,4 +288,14 @@ impl AlephP2p for GrpcService {
                 .collect(),
         }))
     }
+
+    type FetchStream =
+        std::pin::Pin<Box<dyn futures::Stream<Item = Result<proto::FetchChunk, Status>> + Send>>;
+
+    async fn fetch(
+        &self,
+        _request: Request<proto::FetchRequest>,
+    ) -> Result<Response<Self::FetchStream>, Status> {
+        Err(Status::unimplemented("fetch is not available yet"))
+    }
 }

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures::Stream;
 use libp2p::{Multiaddr, PeerId};
@@ -23,6 +24,10 @@ pub struct GrpcService {
     pub subscriptions: Arc<Subscriptions>,
     pub local_peer_id: PeerId,
     pub metrics: Metrics,
+    pub fetch_control: libp2p_stream::Control,
+    pub fetch_settings: crate::fetch::requester::FetchSettings,
+    pub fetch_total_deadline: Duration,
+    pub fetch_cooldowns: Arc<crate::fetch::requester::FetchCooldowns>,
 }
 
 impl GrpcService {
@@ -289,13 +294,117 @@ impl AlephP2p for GrpcService {
         }))
     }
 
-    type FetchStream =
-        std::pin::Pin<Box<dyn futures::Stream<Item = Result<proto::FetchChunk, Status>> + Send>>;
+    type FetchStream = Pin<Box<dyn Stream<Item = Result<proto::FetchChunk, Status>> + Send>>;
 
     async fn fetch(
         &self,
-        _request: Request<proto::FetchRequest>,
+        request: Request<proto::FetchRequest>,
     ) -> Result<Response<Self::FetchStream>, Status> {
-        Err(Status::unimplemented("fetch is not available yet"))
+        let req = request.into_inner();
+        if !crate::fetch::is_valid_item_hash(&req.item_hash) {
+            return Err(Status::invalid_argument("invalid item hash"));
+        }
+        self.metrics.fetch_requests_total.inc();
+
+        // Candidate order: caller hints first (lenient parsing), then
+        // connected peers, preferred first, then by gossipsub score.
+        let mut candidates: Vec<PeerId> = Vec::new();
+        for hint in &req.preferred_peer_ids {
+            if let Ok(peer) = hint.parse::<PeerId>() {
+                if peer != self.local_peer_id && !candidates.contains(&peer) {
+                    candidates.push(peer);
+                }
+            }
+        }
+        let mut client = self.client.clone();
+        let mut connected = client
+            .get_peers()
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+        connected.sort_by(|a, b| {
+            b.preferred.cmp(&a.preferred).then(
+                b.score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+            )
+        });
+        for peer in connected {
+            if peer.peer_id != self.local_peer_id && !candidates.contains(&peer.peer_id) {
+                candidates.push(peer.peer_id);
+            }
+        }
+        if candidates.is_empty() {
+            self.metrics.fetch_request_errors_total.inc();
+            return Err(Status::not_found("no peers available to fetch from"));
+        }
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let control = self.fetch_control.clone();
+        let settings = self.fetch_settings.clone();
+        let cooldowns = self.fetch_cooldowns.clone();
+        let task_metrics = self.metrics.clone();
+        let item_hash = req.item_hash.clone();
+        let deadline = self.fetch_total_deadline;
+        let fetch_task = tokio::spawn(async move {
+            tokio::time::timeout(
+                deadline,
+                crate::fetch::requester::fetch_from_peers(
+                    control,
+                    candidates,
+                    item_hash,
+                    settings,
+                    &cooldowns,
+                    task_metrics,
+                    tx,
+                ),
+            )
+            .await
+        });
+
+        let metrics = self.metrics.clone();
+        let stream = async_stream::stream! {
+            use crate::fetch::requester::{FetchError, FetchProgress};
+            let mut total_size: u64 = 0;
+            let mut sent_any = false;
+            let mut got_header = false;
+            while let Some(progress) = rx.recv().await {
+                match progress {
+                    FetchProgress::Header { size } => {
+                        total_size = size;
+                        got_header = true;
+                    }
+                    FetchProgress::Chunk(data) => {
+                        sent_any = true;
+                        yield Ok(proto::FetchChunk { data, total_size });
+                    }
+                }
+            }
+            match fetch_task.await {
+                Ok(Ok(Ok(()))) => {
+                    if got_header && !sent_any {
+                        // Zero-length content: emit one empty chunk so the
+                        // client can distinguish "found, empty" from errors.
+                        yield Ok(proto::FetchChunk { data: Vec::new(), total_size });
+                    }
+                }
+                Ok(Ok(Err(FetchError::NotFound))) => {
+                    metrics.fetch_request_errors_total.inc();
+                    yield Err(Status::not_found("content not found on any reachable peer"));
+                }
+                Ok(Ok(Err(FetchError::Aborted(reason)))) => {
+                    metrics.fetch_request_errors_total.inc();
+                    yield Err(Status::aborted(reason));
+                }
+                Ok(Err(_elapsed)) => {
+                    metrics.fetch_request_errors_total.inc();
+                    yield Err(Status::deadline_exceeded("fetch deadline exceeded"));
+                }
+                Err(join_error) => {
+                    metrics.fetch_request_errors_total.inc();
+                    yield Err(Status::internal(join_error.to_string()));
+                }
+            }
+        };
+        Ok(Response::new(Box::pin(stream)))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod fetch;
 pub mod grpc;
 pub mod http;
 pub mod metrics;

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,9 +94,7 @@ fn validate_config(app_config: &AppConfig) -> Result<(), Box<dyn std::error::Err
             "Invalid p2p config: maintenance_interval_secs must be at least 1 (0 hot-spins the command channel)".into(),
         );
     }
-    if !p2p.content_provider_url.is_empty()
-        && Url::parse(&p2p.content_provider_url).is_err()
-    {
+    if !p2p.content_provider_url.is_empty() && Url::parse(&p2p.content_provider_url).is_err() {
         return Err(format!(
             "p2p.content_provider_url is not a valid URL: {}",
             p2p.content_provider_url

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,12 +94,8 @@ fn validate_config(app_config: &AppConfig) -> Result<(), Box<dyn std::error::Err
             "Invalid p2p config: maintenance_interval_secs must be at least 1 (0 hot-spins the command channel)".into(),
         );
     }
-    if !p2p.content_provider_url.is_empty() && Url::parse(&p2p.content_provider_url).is_err() {
-        return Err(format!(
-            "p2p.content_provider_url is not a valid URL: {}",
-            p2p.content_provider_url
-        )
-        .into());
+    if !p2p.ipfs_api_url.is_empty() && Url::parse(&p2p.ipfs_api_url).is_err() {
+        return Err(format!("p2p.ipfs_api_url is not a valid URL: {}", p2p.ipfs_api_url).into());
     }
     if p2p.fetch_max_peer_attempts == 0 {
         return Err("p2p.fetch_max_peer_attempts must be >= 1".into());
@@ -243,12 +239,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ));
 
     // Provider side of the fetch protocol: serve inbound /aleph/fetch streams
-    // by proxying the local pyaleph API (disabled while the URL is empty).
+    // from the local content store and/or local Kubo. Disabled when both
+    // content_dir and ipfs_api_url are empty.
     let provider_settings = fetch::provider::ProviderSettings {
-        provider_url: if app_config.p2p.content_provider_url.is_empty() {
+        content_dir: if app_config.p2p.content_dir.is_empty() {
             None
         } else {
-            Some(app_config.p2p.content_provider_url.clone())
+            Some(std::path::PathBuf::from(&app_config.p2p.content_dir))
+        },
+        ipfs_api_url: if app_config.p2p.ipfs_api_url.is_empty() {
+            None
+        } else {
+            Some(app_config.p2p.ipfs_api_url.clone())
         },
         max_size_bytes: app_config.p2p.fetch_max_size_bytes,
         max_inbound_streams: app_config.p2p.fetch_max_inbound_streams,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use aleph_p2p_service::p2p::network::{NetworkSettings, P2PClient};
 use aleph_p2p_service::p2p::peerstore::PeerStore;
 use aleph_p2p_service::subscriptions::Subscriptions;
 use aleph_p2p_service::{http, p2p};
+use reqwest::Url;
 use tokio_stream::wrappers::TcpListenerStream;
 
 #[derive(Parser, Debug)]
@@ -92,6 +93,27 @@ fn validate_config(app_config: &AppConfig) -> Result<(), Box<dyn std::error::Err
         return Err(
             "Invalid p2p config: maintenance_interval_secs must be at least 1 (0 hot-spins the command channel)".into(),
         );
+    }
+    if !p2p.content_provider_url.is_empty()
+        && Url::parse(&p2p.content_provider_url).is_err()
+    {
+        return Err(format!(
+            "p2p.content_provider_url is not a valid URL: {}",
+            p2p.content_provider_url
+        )
+        .into());
+    }
+    if p2p.fetch_max_peer_attempts == 0 {
+        return Err("p2p.fetch_max_peer_attempts must be >= 1".into());
+    }
+    if p2p.fetch_peer_timeout_secs == 0 || p2p.fetch_total_deadline_secs == 0 {
+        return Err("p2p fetch timeouts must be >= 1 second".into());
+    }
+    if p2p.fetch_total_deadline_secs < p2p.fetch_peer_timeout_secs {
+        return Err("p2p.fetch_total_deadline_secs must be >= fetch_peer_timeout_secs".into());
+    }
+    if p2p.fetch_max_inbound_streams == 0 || p2p.fetch_max_inbound_streams_per_peer == 0 {
+        return Err("p2p fetch inbound stream limits must be >= 1".into());
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use aleph_p2p_service::metrics::Metrics;
 use aleph_p2p_service::p2p::network::{NetworkSettings, P2PClient};
 use aleph_p2p_service::p2p::peerstore::PeerStore;
 use aleph_p2p_service::subscriptions::Subscriptions;
-use aleph_p2p_service::{http, p2p};
+use aleph_p2p_service::{fetch, http, p2p};
 use reqwest::Url;
 use tokio_stream::wrappers::TcpListenerStream;
 
@@ -189,8 +189,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let bootstrap_peers = bootstrap_peer_ids(&app_config.p2p.peers);
 
-    // The fetch control is consumed by the Fetch RPC wiring in a later task.
-    let (mut network_client, network_event_loop, _fetch_control) = p2p::network::new(
+    let (mut network_client, network_event_loop, fetch_control) = p2p::network::new(
         id_keys,
         network_settings,
         bootstrap_peers,
@@ -243,11 +242,43 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         peerstore.clone(),
     ));
 
+    // Provider side of the fetch protocol: serve inbound /aleph/fetch streams
+    // by proxying the local pyaleph API (disabled while the URL is empty).
+    let provider_settings = fetch::provider::ProviderSettings {
+        provider_url: if app_config.p2p.content_provider_url.is_empty() {
+            None
+        } else {
+            Some(app_config.p2p.content_provider_url.clone())
+        },
+        max_size_bytes: app_config.p2p.fetch_max_size_bytes,
+        max_inbound_streams: app_config.p2p.fetch_max_inbound_streams,
+        max_inbound_streams_per_peer: app_config.p2p.fetch_max_inbound_streams_per_peer,
+        serve_bytes_per_sec: app_config.p2p.fetch_serve_bytes_per_sec,
+    };
+    let fetch_settings = fetch::requester::FetchSettings {
+        peer_timeout: Duration::from_secs(app_config.p2p.fetch_peer_timeout_secs),
+        max_size_bytes: app_config.p2p.fetch_max_size_bytes,
+        max_peer_attempts: app_config.p2p.fetch_max_peer_attempts,
+    };
+    let incoming_fetch_streams = fetch_control
+        .clone()
+        .accept(fetch::FETCH_PROTOCOL)
+        .expect("fetch protocol registered twice");
+    let fetch_provider_handle = tokio::spawn(fetch::provider::run(
+        incoming_fetch_streams,
+        provider_settings,
+        metrics.clone(),
+    ));
+
     let grpc_service = aleph_p2p_service::grpc::GrpcService {
         client: network_client.clone(),
         subscriptions: subscriptions.clone(),
         local_peer_id: peer_id,
         metrics: metrics.clone(),
+        fetch_control,
+        fetch_settings,
+        fetch_total_deadline: Duration::from_secs(app_config.p2p.fetch_total_deadline_secs),
+        fetch_cooldowns: Arc::new(fetch::requester::FetchCooldowns::default()),
     };
     let grpc_bind_addr: std::net::SocketAddr = format!(
         "{}:{}",
@@ -329,6 +360,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         maintenance_handle.abort_handle(),
         peerstore_flush_handle.abort_handle(),
         http_server_handle.abort_handle(),
+        fetch_provider_handle.abort_handle(),
     ];
 
     let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
@@ -340,6 +372,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         _ = maintenance_handle => { error!("Critical task 'maintenance' ended"); 1 }
         _ = peerstore_flush_handle => { error!("Critical task 'peerstore-flusher' ended"); 1 }
         _ = http_server_handle => { error!("Critical task 'metrics-http' ended"); 1 }
+        _ = fetch_provider_handle => { error!("Critical task 'fetch-provider' ended"); 1 }
         _ = tokio::signal::ctrl_c() => { info!("Shutdown signal received (SIGINT)"); 0 }
         _ = sigterm.recv() => { info!("Shutdown signal received (SIGTERM)"); 0 }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let bootstrap_peers = bootstrap_peer_ids(&app_config.p2p.peers);
 
-    let (mut network_client, network_event_loop) = p2p::network::new(
+    // The fetch control is consumed by the Fetch RPC wiring in a later task.
+    let (mut network_client, network_event_loop, _fetch_control) = p2p::network::new(
         id_keys,
         network_settings,
         bootstrap_peers,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -24,6 +24,15 @@ pub struct Metrics {
 
     // HTTP metrics
     pub http_requests_total: Counter,
+
+    // Fetch protocol (provider side)
+    pub fetch_served_total: Counter,
+    pub fetch_serve_errors_total: Counter,
+    pub fetch_bytes_served_total: Counter,
+    // Fetch protocol (requester side)
+    pub fetch_requests_total: Counter,
+    pub fetch_request_errors_total: Counter,
+    pub fetch_bytes_fetched_total: Counter,
 }
 
 impl Default for Metrics {
@@ -78,6 +87,43 @@ impl Metrics {
             http_requests_total.clone(),
         );
 
+        let fetch_served_total = Counter::default();
+        registry.register(
+            "fetch_served_total",
+            "Inbound fetch requests answered with content",
+            fetch_served_total.clone(),
+        );
+        let fetch_serve_errors_total = Counter::default();
+        registry.register(
+            "fetch_serve_errors_total",
+            "Inbound fetch requests rejected or failed (not found, over limit, backend error)",
+            fetch_serve_errors_total.clone(),
+        );
+        let fetch_bytes_served_total = Counter::default();
+        registry.register(
+            "fetch_bytes_served_total",
+            "Content bytes served to remote peers over the fetch protocol",
+            fetch_bytes_served_total.clone(),
+        );
+        let fetch_requests_total = Counter::default();
+        registry.register(
+            "fetch_requests_total",
+            "Outbound Fetch RPCs started",
+            fetch_requests_total.clone(),
+        );
+        let fetch_request_errors_total = Counter::default();
+        registry.register(
+            "fetch_request_errors_total",
+            "Outbound Fetch RPCs that failed (not found, deadline, aborted)",
+            fetch_request_errors_total.clone(),
+        );
+        let fetch_bytes_fetched_total = Counter::default();
+        registry.register(
+            "fetch_bytes_fetched_total",
+            "Content bytes fetched from remote peers over the fetch protocol",
+            fetch_bytes_fetched_total.clone(),
+        );
+
         Self {
             registry: Arc::new(registry),
             connected_peers,
@@ -86,6 +132,12 @@ impl Metrics {
             p2p_events,
             memory_usage_bytes,
             http_requests_total,
+            fetch_served_total,
+            fetch_serve_errors_total,
+            fetch_bytes_served_total,
+            fetch_requests_total,
+            fetch_request_errors_total,
+            fetch_bytes_fetched_total,
         }
     }
 

--- a/src/p2p/network.rs
+++ b/src/p2p/network.rs
@@ -47,6 +47,7 @@ pub struct NetworkSettings {
 pub struct Behaviour {
     gossipsub: GossipsubBehaviour,
     identify: identify::Behaviour,
+    stream: libp2p_stream::Behaviour,
 }
 
 fn make_gossipsub_config() -> gossipsub::Config {
@@ -86,7 +87,7 @@ pub async fn new(
     metrics: Metrics,
     subscriptions: Arc<Subscriptions>,
     peerstore: Arc<Mutex<PeerStore>>,
-) -> Result<(P2PClient, EventLoop), Box<dyn Error>> {
+) -> Result<(P2PClient, EventLoop, libp2p_stream::Control), Box<dyn Error>> {
     let swarm = libp2p::SwarmBuilder::with_existing_identity(id_keys)
         .with_tokio()
         .with_tcp(
@@ -121,12 +122,17 @@ pub async fn new(
             Behaviour {
                 gossipsub,
                 identify,
+                stream: libp2p_stream::Behaviour::new(),
             }
         })?
         // Gossipsub mesh links see periodic traffic; non-mesh connections
         // must survive between heartbeats and maintenance ticks.
         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(300)))
         .build();
+
+    // Handle for opening outbound fetch streams; usable independently of the
+    // EventLoop because libp2p-stream drives its own protocol handling.
+    let fetch_control = swarm.behaviour().stream.new_control();
 
     let (command_sender, command_receiver) = mpsc::channel(0);
     Ok((
@@ -142,6 +148,7 @@ pub async fn new(
             settings,
             bootstrap_peers,
         ),
+        fetch_control,
     ))
 }
 
@@ -430,6 +437,9 @@ impl EventLoop {
             SwarmEvent::Behaviour(BehaviourEvent::Identify(other)) => {
                 debug!("Identify event: {:?}", other);
             }
+            // The stream behaviour emits no events; streams are handled
+            // through the Control returned by `new`.
+            SwarmEvent::Behaviour(BehaviourEvent::Stream(())) => {}
             SwarmEvent::ConnectionEstablished {
                 peer_id,
                 endpoint,

--- a/tests/fetch_two_nodes.rs
+++ b/tests/fetch_two_nodes.rs
@@ -1,0 +1,280 @@
+//! End-to-end coverage of the /aleph/fetch/1.0.0 protocol between two
+//! in-process nodes: node A serves content from a mock pyaleph backend,
+//! node B fetches it over a libp2p stream (directly via the requester and
+//! through the gRPC Fetch handler).
+
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use libp2p::{identity, Multiaddr, PeerId};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::mpsc;
+use tonic::Request;
+
+use aleph_p2p_service::fetch::requester::{
+    fetch_from_peers, FetchCooldowns, FetchError, FetchProgress, FetchSettings,
+};
+use aleph_p2p_service::fetch::{provider, FETCH_PROTOCOL};
+use aleph_p2p_service::grpc::proto::aleph_p2p_server::AlephP2p;
+use aleph_p2p_service::grpc::{proto, GrpcService};
+use aleph_p2p_service::metrics::Metrics;
+use aleph_p2p_service::p2p::network::{self, NetworkSettings, P2PClient};
+use aleph_p2p_service::p2p::peerstore::PeerStore;
+use aleph_p2p_service::subscriptions::Subscriptions;
+
+fn default_settings() -> NetworkSettings {
+    NetworkSettings {
+        low_water: 80,
+        high_water: 160,
+        per_subnet_cap: 4,
+        max_protected_share: 0.5,
+    }
+}
+
+/// Deterministic payload large enough to span several 64 KiB chunks.
+fn payload_300_kib() -> Vec<u8> {
+    (0..300 * 1024).map(|i| (i % 251) as u8).collect()
+}
+
+/// Serves HTTP requests: 200 with `content` for /api/v0/storage/raw/<known_hash>,
+/// 404 otherwise. Closes the connection after responding.
+/// (Copied from the provider unit tests; integration tests cannot import
+/// #[cfg(test)] items.)
+async fn mock_backend(known_hash: String, content: Vec<u8>) -> std::net::SocketAddr {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                return;
+            };
+            let known_hash = known_hash.clone();
+            let content = content.clone();
+            tokio::spawn(async move {
+                let mut buf = vec![0u8; 4096];
+                let n = socket.read(&mut buf).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]).to_string();
+                let response = if request.contains(&known_hash) {
+                    let mut r = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                        content.len()
+                    )
+                    .into_bytes();
+                    r.extend_from_slice(&content);
+                    r
+                } else {
+                    b"HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+                        .to_vec()
+                };
+                let _ = socket.write_all(&response).await;
+            });
+        }
+    });
+    addr
+}
+
+struct Node {
+    client: P2PClient,
+    control: libp2p_stream::Control,
+    subscriptions: Arc<Subscriptions>,
+}
+
+async fn start_node() -> Node {
+    let subscriptions = Arc::new(Subscriptions::new(1024));
+    let (client, event_loop, control) = network::new(
+        identity::Keypair::generate_ed25519(),
+        default_settings(),
+        HashSet::new(),
+        Metrics::new(),
+        subscriptions.clone(),
+        Arc::new(Mutex::new(PeerStore::default())),
+    )
+    .await
+    .unwrap();
+    tokio::spawn(event_loop.run());
+    Node {
+        client,
+        control,
+        subscriptions,
+    }
+}
+
+/// Starts listening on `node` and polls until a listen address is reported.
+async fn listen_addr(node: &mut Node) -> (PeerId, Multiaddr) {
+    node.client
+        .start_listening("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+        .await
+        .unwrap();
+    for _ in 0..50 {
+        let info = node.client.identify().await.unwrap();
+        if let Some(addr) = info.listen_multiaddrs.first() {
+            return (info.peer_id, addr.clone());
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("node never reported a listen address within 5 seconds");
+}
+
+fn provider_settings(provider_url: Option<String>) -> provider::ProviderSettings {
+    provider::ProviderSettings {
+        provider_url,
+        max_size_bytes: 1024 * 1024,
+        max_inbound_streams: 4,
+        max_inbound_streams_per_peer: 2,
+        serve_bytes_per_sec: 0,
+    }
+}
+
+fn fetch_settings() -> FetchSettings {
+    FetchSettings {
+        peer_timeout: Duration::from_secs(10),
+        max_size_bytes: 1024 * 1024,
+        max_peer_attempts: 5,
+    }
+}
+
+/// Two connected nodes: A serves `content` for `known_hash` from a mock
+/// backend, B is dialed in and ready to fetch. Node A is returned too so its
+/// command channel (and with it the event loop) stays alive for the test.
+async fn connected_pair(known_hash: String, content: Vec<u8>) -> (Node, PeerId, Node) {
+    let mut node_a = start_node().await;
+    let mut node_b = start_node().await;
+
+    let backend_addr = mock_backend(known_hash, content).await;
+    let incoming = node_a
+        .control
+        .clone()
+        .accept(FETCH_PROTOCOL)
+        .expect("fetch protocol registered twice");
+    tokio::spawn(provider::run(
+        incoming,
+        provider_settings(Some(format!("http://{}", backend_addr))),
+        Metrics::new(),
+    ));
+
+    let (peer_a, addr_a) = listen_addr(&mut node_a).await;
+    node_b
+        .client
+        .dial_and_wait(peer_a, vec![addr_a])
+        .await
+        .unwrap();
+    // Settle delay: the connection is established, give the stream protocol
+    // negotiation a moment before opening fetch streams.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    (node_a, peer_a, node_b)
+}
+
+#[tokio::test]
+async fn fetch_roundtrip() {
+    let hash = "a".repeat(64);
+    let content = payload_300_kib();
+    let (_node_a, peer_a, node_b) = connected_pair(hash.clone(), content.clone()).await;
+
+    let (tx, mut rx) = mpsc::channel(16);
+    let collector = tokio::spawn(async move {
+        let mut header_size = None;
+        let mut chunks: Vec<Vec<u8>> = Vec::new();
+        while let Some(progress) = rx.recv().await {
+            match progress {
+                FetchProgress::Header { size } => header_size = Some(size),
+                FetchProgress::Chunk(data) => chunks.push(data),
+            }
+        }
+        (header_size, chunks)
+    });
+
+    let cooldowns = FetchCooldowns::default();
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        fetch_from_peers(
+            node_b.control.clone(),
+            vec![peer_a],
+            hash,
+            fetch_settings(),
+            &cooldowns,
+            Metrics::new(),
+            tx,
+        ),
+    )
+    .await
+    .expect("fetch timed out");
+    assert!(result.is_ok(), "fetch failed: {:?}", result.err());
+
+    let (header_size, chunks) = collector.await.unwrap();
+    assert_eq!(header_size, Some(content.len() as u64));
+    assert!(
+        chunks.len() > 1,
+        "expected multiple chunks for a 300 KiB payload, got {}",
+        chunks.len()
+    );
+    let reassembled: Vec<u8> = chunks.concat();
+    assert_eq!(reassembled, content);
+}
+
+#[tokio::test]
+async fn fetch_not_found_falls_through() {
+    let known_hash = "a".repeat(64);
+    let (_node_a, peer_a, node_b) = connected_pair(known_hash, b"some content".to_vec()).await;
+
+    let (tx, mut rx) = mpsc::channel(16);
+    let cooldowns = FetchCooldowns::default();
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        fetch_from_peers(
+            node_b.control.clone(),
+            vec![peer_a],
+            "b".repeat(64),
+            fetch_settings(),
+            &cooldowns,
+            Metrics::new(),
+            tx,
+        ),
+    )
+    .await
+    .expect("fetch timed out");
+    assert!(matches!(result, Err(FetchError::NotFound)));
+    // An honest miss forwards nothing to the consumer.
+    assert!(rx.recv().await.is_none());
+    // And does not penalize the peer.
+    assert!(!cooldowns.is_cooling(&peer_a));
+}
+
+#[tokio::test]
+async fn fetch_grpc_end_to_end() {
+    let hash = "a".repeat(64);
+    let content = payload_300_kib();
+    let (_node_a, peer_a, node_b) = connected_pair(hash.clone(), content.clone()).await;
+
+    let local_peer_id = node_b.client.clone().identify().await.unwrap().peer_id;
+    let service = GrpcService {
+        client: node_b.client.clone(),
+        subscriptions: node_b.subscriptions.clone(),
+        local_peer_id,
+        metrics: Metrics::new(),
+        fetch_control: node_b.control.clone(),
+        fetch_settings: fetch_settings(),
+        fetch_total_deadline: Duration::from_secs(30),
+        fetch_cooldowns: Arc::new(FetchCooldowns::default()),
+    };
+
+    let response = service
+        .fetch(Request::new(proto::FetchRequest {
+            item_hash: hash,
+            preferred_peer_ids: vec![peer_a.to_string()],
+        }))
+        .await
+        .expect("fetch call failed");
+    let mut stream = response.into_inner();
+
+    let mut reassembled = Vec::new();
+    let mut total_size = None;
+    while let Some(chunk) = futures::StreamExt::next(&mut stream).await {
+        let chunk = chunk.expect("fetch stream failed");
+        total_size = Some(chunk.total_size);
+        reassembled.extend_from_slice(&chunk.data);
+    }
+    assert_eq!(total_size, Some(content.len() as u64));
+    assert_eq!(reassembled, content);
+}

--- a/tests/fetch_two_nodes.rs
+++ b/tests/fetch_two_nodes.rs
@@ -1,5 +1,5 @@
 //! End-to-end coverage of the /aleph/fetch/1.0.0 protocol between two
-//! in-process nodes: node A serves content from a mock pyaleph backend,
+//! in-process nodes: node A serves content from a local filesystem store,
 //! node B fetches it over a libp2p stream (directly via the requester and
 //! through the gRPC Fetch handler).
 
@@ -8,7 +8,6 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use libp2p::{identity, Multiaddr, PeerId};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::mpsc;
 use tonic::Request;
 
@@ -37,41 +36,12 @@ fn payload_300_kib() -> Vec<u8> {
     (0..300 * 1024).map(|i| (i % 251) as u8).collect()
 }
 
-/// Serves HTTP requests: 200 with `content` for /api/v0/storage/raw/<known_hash>,
-/// 404 otherwise. Closes the connection after responding.
-/// (Copied from the provider unit tests; integration tests cannot import
-/// #[cfg(test)] items.)
-async fn mock_backend(known_hash: String, content: Vec<u8>) -> std::net::SocketAddr {
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    tokio::spawn(async move {
-        loop {
-            let Ok((mut socket, _)) = listener.accept().await else {
-                return;
-            };
-            let known_hash = known_hash.clone();
-            let content = content.clone();
-            tokio::spawn(async move {
-                let mut buf = vec![0u8; 4096];
-                let n = socket.read(&mut buf).await.unwrap_or(0);
-                let request = String::from_utf8_lossy(&buf[..n]).to_string();
-                let response = if request.contains(&known_hash) {
-                    let mut r = format!(
-                        "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
-                        content.len()
-                    )
-                    .into_bytes();
-                    r.extend_from_slice(&content);
-                    r
-                } else {
-                    b"HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
-                        .to_vec()
-                };
-                let _ = socket.write_all(&response).await;
-            });
-        }
-    });
-    addr
+/// Writes `content` to `dir/known_hash` so the provider can serve it from
+/// the filesystem store.
+async fn write_content(dir: &std::path::Path, known_hash: &str, content: &[u8]) {
+    tokio::fs::write(dir.join(known_hash), content)
+        .await
+        .unwrap();
 }
 
 struct Node {
@@ -116,9 +86,10 @@ async fn listen_addr(node: &mut Node) -> (PeerId, Multiaddr) {
     panic!("node never reported a listen address within 5 seconds");
 }
 
-fn provider_settings(provider_url: Option<String>) -> provider::ProviderSettings {
+fn provider_settings(content_dir: Option<std::path::PathBuf>) -> provider::ProviderSettings {
     provider::ProviderSettings {
-        provider_url,
+        content_dir,
+        ipfs_api_url: None,
         max_size_bytes: 1024 * 1024,
         max_inbound_streams: 4,
         max_inbound_streams_per_peer: 2,
@@ -134,14 +105,21 @@ fn fetch_settings() -> FetchSettings {
     }
 }
 
-/// Two connected nodes: A serves `content` for `known_hash` from a mock
-/// backend, B is dialed in and ready to fetch. Node A is returned too so its
-/// command channel (and with it the event loop) stays alive for the test.
-async fn connected_pair(known_hash: String, content: Vec<u8>) -> (Node, PeerId, Node) {
+/// Two connected nodes: A serves `content` for `known_hash` from the local
+/// filesystem store, B is dialed in and ready to fetch. Node A is returned
+/// too so its command channel (and with it the event loop) stays alive for
+/// the test. The returned `tempfile::TempDir` must be kept alive for the
+/// duration of the test.
+async fn connected_pair(
+    known_hash: String,
+    content: Vec<u8>,
+) -> (Node, PeerId, Node, tempfile::TempDir) {
     let mut node_a = start_node().await;
     let mut node_b = start_node().await;
 
-    let backend_addr = mock_backend(known_hash, content).await;
+    let dir = tempfile::tempdir().unwrap();
+    write_content(dir.path(), &known_hash, &content).await;
+
     let incoming = node_a
         .control
         .clone()
@@ -149,7 +127,7 @@ async fn connected_pair(known_hash: String, content: Vec<u8>) -> (Node, PeerId, 
         .expect("fetch protocol registered twice");
     tokio::spawn(provider::run(
         incoming,
-        provider_settings(Some(format!("http://{}", backend_addr))),
+        provider_settings(Some(dir.path().to_path_buf())),
         Metrics::new(),
     ));
 
@@ -163,14 +141,14 @@ async fn connected_pair(known_hash: String, content: Vec<u8>) -> (Node, PeerId, 
     // negotiation a moment before opening fetch streams.
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    (node_a, peer_a, node_b)
+    (node_a, peer_a, node_b, dir)
 }
 
 #[tokio::test]
 async fn fetch_roundtrip() {
     let hash = "a".repeat(64);
     let content = payload_300_kib();
-    let (_node_a, peer_a, node_b) = connected_pair(hash.clone(), content.clone()).await;
+    let (_node_a, peer_a, node_b, _dir) = connected_pair(hash.clone(), content.clone()).await;
 
     let (tx, mut rx) = mpsc::channel(16);
     let collector = tokio::spawn(async move {
@@ -216,7 +194,8 @@ async fn fetch_roundtrip() {
 #[tokio::test]
 async fn fetch_not_found_falls_through() {
     let known_hash = "a".repeat(64);
-    let (_node_a, peer_a, node_b) = connected_pair(known_hash, b"some content".to_vec()).await;
+    let (_node_a, peer_a, node_b, _dir) =
+        connected_pair(known_hash, b"some content".to_vec()).await;
 
     let (tx, mut rx) = mpsc::channel(16);
     let cooldowns = FetchCooldowns::default();
@@ -245,7 +224,7 @@ async fn fetch_not_found_falls_through() {
 async fn fetch_grpc_end_to_end() {
     let hash = "a".repeat(64);
     let content = payload_300_kib();
-    let (_node_a, peer_a, node_b) = connected_pair(hash.clone(), content.clone()).await;
+    let (_node_a, peer_a, node_b, _dir) = connected_pair(hash.clone(), content.clone()).await;
 
     let local_peer_id = node_b.client.clone().identify().await.unwrap().peer_id;
     let service = GrpcService {

--- a/tests/gossip_two_nodes.rs
+++ b/tests/gossip_two_nodes.rs
@@ -26,7 +26,7 @@ async fn two_new_nodes_exchange_gossipsub_messages() {
     let subscriptions_a = Arc::new(Subscriptions::new(1024));
     let subscriptions_b = Arc::new(Subscriptions::new(1024));
 
-    let (mut client_a, loop_a) = network::new(
+    let (mut client_a, loop_a, _fetch_control_a) = network::new(
         identity::Keypair::generate_ed25519(),
         default_settings(),
         HashSet::new(),
@@ -36,7 +36,7 @@ async fn two_new_nodes_exchange_gossipsub_messages() {
     )
     .await
     .unwrap();
-    let (mut client_b, loop_b) = network::new(
+    let (mut client_b, loop_b, _fetch_control_b) = network::new(
         identity::Keypair::generate_ed25519(),
         default_settings(),
         HashSet::new(),

--- a/tests/grpc_roundtrip.rs
+++ b/tests/grpc_roundtrip.rs
@@ -17,7 +17,7 @@ use aleph_p2p_service::subscriptions::Subscriptions;
 
 async fn start_service() -> (AlephP2pClient<Channel>, String) {
     let subscriptions = Arc::new(Subscriptions::new(1024));
-    let (mut client, event_loop) = network::new(
+    let (mut client, event_loop, _fetch_control) = network::new(
         libp2p::identity::Keypair::generate_ed25519(),
         NetworkSettings {
             low_water: 80,

--- a/tests/grpc_roundtrip.rs
+++ b/tests/grpc_roundtrip.rs
@@ -4,9 +4,10 @@ use std::time::Duration;
 
 use tonic::transport::Channel;
 
+use aleph_p2p_service::fetch::requester::{FetchCooldowns, FetchSettings};
 use aleph_p2p_service::grpc::proto::aleph_p2p_client::AlephP2pClient;
 use aleph_p2p_service::grpc::proto::{
-    DialRequest, GetPeersRequest, IdentifyRequest, PreferredPeer, PublishRequest,
+    DialRequest, FetchRequest, GetPeersRequest, IdentifyRequest, PreferredPeer, PublishRequest,
     SetPreferredPeersRequest, SubscribeRequest,
 };
 use aleph_p2p_service::grpc::GrpcService;
@@ -17,7 +18,7 @@ use aleph_p2p_service::subscriptions::Subscriptions;
 
 async fn start_service() -> (AlephP2pClient<Channel>, String) {
     let subscriptions = Arc::new(Subscriptions::new(1024));
-    let (mut client, event_loop, _fetch_control) = network::new(
+    let (mut client, event_loop, fetch_control) = network::new(
         libp2p::identity::Keypair::generate_ed25519(),
         NetworkSettings {
             low_water: 80,
@@ -56,6 +57,14 @@ async fn start_service() -> (AlephP2pClient<Channel>, String) {
         subscriptions,
         local_peer_id: peer_id,
         metrics: Metrics::new(),
+        fetch_control,
+        fetch_settings: FetchSettings {
+            peer_timeout: Duration::from_secs(2),
+            max_size_bytes: 256 * 1024 * 1024,
+            max_peer_attempts: 5,
+        },
+        fetch_total_deadline: Duration::from_secs(5),
+        fetch_cooldowns: Arc::new(FetchCooldowns::default()),
     };
     tokio::spawn(async move {
         tonic::transport::Server::builder()
@@ -161,6 +170,27 @@ async fn publish_empty_topic_returns_invalid_argument() {
         .await
         .unwrap_err();
     assert_eq!(err.code(), tonic::Code::InvalidArgument);
+}
+
+#[tokio::test]
+async fn fetch_without_peers_is_not_found() {
+    let (mut grpc, _peer_id) = start_service().await;
+    let result = grpc
+        .fetch(FetchRequest {
+            item_hash: "a".repeat(64),
+            preferred_peer_ids: vec![],
+        })
+        .await
+        .map(|r| r.into_inner());
+    // The error can surface either at call time or on the first message.
+    let status = match result {
+        Err(status) => status,
+        Ok(mut stream) => match stream.message().await {
+            Err(status) => status,
+            Ok(msg) => panic!("expected NOT_FOUND, got {:?}", msg),
+        },
+    };
+    assert_eq!(status.code(), tonic::Code::NotFound);
 }
 
 #[tokio::test]

--- a/tests/interop_old_libp2p.rs
+++ b/tests/interop_old_libp2p.rs
@@ -61,7 +61,7 @@ async fn new_node_interops_with_libp2p_0_51_node() {
 
     // New node.
     let subscriptions = Arc::new(Subscriptions::new(1024));
-    let (mut new_client, new_loop) = network::new(
+    let (mut new_client, new_loop, _fetch_control) = network::new(
         libp2p::identity::Keypair::generate_ed25519(),
         NetworkSettings {
             low_water: 80,


### PR DESCRIPTION
Stacked on #67. Ships as part of v2.0: the crate version stays 2.0.0 and the intermediate no-fetch state is never released separately.

## What this adds

A libp2p stream protocol for retrieving hash-addressed content directly from peers over the existing Noise-authenticated connections, replacing the unauthenticated HTTP fallback as the primary non-local fetch path (design doc section 4.4).

### Wire protocol
- `/aleph/fetch/1.0.0`, via `libp2p-stream` (request-response cannot stream 256 MiB content).
- Length-prefixed (u32 BE, max 4096) CBOR frames: request `{item_hash, offset}` and response header `{found, size}`, then raw content in 64 KiB chunks.
- Purely additive on the wire: gossipsub, identify and the transport stack are untouched, and the libp2p 0.51 interop test still passes.

### Requester (gRPC `Fetch`, server-streaming)
- Candidate order: caller hints first, then connected peers sorted preferred-first then by gossipsub score.
- Bounded attempts (5 peers), 10 s per-peer step timeout, 60 s total deadline (all configurable).
- Failed peers get a 60 s cooldown, standing in for a gossipsub behaviour penalty (gossipsub 0.49 has no API to inject one). Dial failures to unreachable hinted peers and our own consumer disconnecting do not penalize the peer; peers without fetch support do get cooled down, so transition-era fetches do not burn their attempts on old nodes.
- Content hashes are verified by pyaleph, never here; this side only enforces the size cap.

### Provider
- Holds no storage: proxies `GET {content_provider_url}/api/v0/storage/raw/{hash}` from the local pyaleph API and relays the body.
- Disabled by default: while `p2p.content_provider_url` is empty every request is answered `found: false`, so existing deployments are unaffected.
- Limits: 256 MiB size cap, 32 global / 4 per-peer concurrent inbound streams, token-bucket byte rate limit (64 MiB/s default), per-write timeouts towards the peer (a requester that stops reading cannot pin serving slots), connect + read-inactivity timeouts towards the backend.
- Hash input validated (alphanumeric, max 128 chars) before URL interpolation.

### Config additions
`content_provider_url`, `fetch_max_size_bytes`, `fetch_max_inbound_streams`, `fetch_max_inbound_streams_per_peer`, `fetch_serve_bytes_per_sec`, `fetch_peer_timeout_secs`, `fetch_total_deadline_secs`, `fetch_max_peer_attempts`; all defaulted, old config files keep working. New Prometheus counters for both sides.

## Notes
- reqwest is pinned to 0.12: 0.13 pulls `time` 0.3.48, which conflicts with actix-web's `cookie` 0.16 (documented in Cargo.toml).
- The gRPC API remains deployment-internal and unauthenticated; the new remote surface is the libp2p protocol, which serves nothing until `content_provider_url` is set.

## Testing
- 57 tests: wire roundtrips and malformed-frame rejection, provider unit tests against a mock HTTP backend (not found, oversize, disabled, traversal attempts), requester cooldown and attempt-cap tests, gRPC roundtrip incl. `Fetch` with no peers, a two-node end-to-end fetch (multi-chunk 300 KiB payload, gRPC stream reassembly), and the libp2p 0.51 wire-compat interop gate.
- clippy `-D warnings` and rustfmt clean; docker base image unchanged (rust:1.88 covers all new MSRVs).